### PR TITLE
Added shortcut Ctrl + enter for browser

### DIFF
--- a/webtoolbar.py
+++ b/webtoolbar.py
@@ -209,6 +209,15 @@ class WebEntry(iconentry.IconEntry):
         selection = self._search_view.get_selection()
         model, selected = selection.get_selected()
 
+        if event.get_state() & Gdk.ModifierType.CONTROL_MASK:
+            if keyname == 'Return':
+                m = re.search('\.',self.props.text)
+                if m is None:
+                    self._set_text("www."+self.props.text+".com")
+                    self.activate(self.props.text)
+                    return True
+                self.activate(self.props.text)
+
         if keyname == 'Up':
             if selected is None:
                 selection.select_iter(model[-1].iter)


### PR DESCRIPTION
Basically, Ctrl + enter key shortcut adds 'www.' prefix and '.com' as suffix to the entered text in the url text box. 