### PR TITLE
Patches for bookmarks

### DIFF
--- a/linkbutton.py
+++ b/linkbutton.py
@@ -26,6 +26,8 @@ import cairo
 from gettext import gettext as _
 import re
 
+from sugar3.graphics.palettemenu import PaletteMenuItem
+from sugar3.graphics.palettemenu import PaletteMenuBox
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.tray import TrayButton
 from sugar3.graphics import style
@@ -103,9 +105,13 @@ class LinkButton(TrayButton, GObject.GObject):
         palette = Palette(info, text_maxlen=50)
         self.set_palette(palette)
 
-        menu_item = Gtk.MenuItem(_('Remove'))
+        box = PaletteMenuBox()
+        palette.set_content(box)
+        box.show()
+
+        menu_item = PaletteMenuItem(_('Remove'), 'list-remove')
         menu_item.connect('activate', self.item_remove_cb)
-        palette.menu.append(menu_item)
+        box.append_item(menu_item)
         menu_item.show()
 
     def item_remove_cb(self, widget):

--- a/model.py
+++ b/model.py
@@ -58,6 +58,11 @@ class Model(GObject.GObject):
                 self.data['shared_links'].remove(link)
                 break
 
+    def change_link_notes(self, hash, notes):
+        for link in self.data['shared_links']:
+            if link['hash'] == hash:
+                link['notes'] = notes
+
     def serialize(self):
         return json.dumps(self.data)
 

--- a/webactivity.py
+++ b/webactivity.py
@@ -400,7 +400,8 @@ class WebActivity(activity.Activity):
                 self._add_link_totray(link['url'],
                                       base64.b64decode(link['thumb']),
                                       link['color'], link['title'],
-                                      link['owner'], -1, link['hash'])
+                                      link['owner'], -1, link['hash'],
+                                      link['notes'])
             logging.debug('########## reading %s', data)
             self._tabbed_view.set_history(self.model.data['history'])
             for number, tab in enumerate(self.model.data['currents']):
@@ -606,13 +607,16 @@ class WebActivity(activity.Activity):
         link = self.model.data['shared_links'][index]
         self._add_link_totray(link['url'], base64.b64decode(link['thumb']),
                               link['color'], link['title'],
-                              link['owner'], index, link['hash'])
+                              link['owner'], index, link['hash'],
+                              link.get('notes'))
 
-    def _add_link_totray(self, url, buf, color, title, owner, index, hash):
+    def _add_link_totray(self, url, buf, color, title, owner, index, hash,
+                         notes=None):
         ''' add a link to the tray '''
-        item = LinkButton(buf, color, title, owner, hash)
+        item = LinkButton(buf, color, title, owner, hash, notes)
         item.connect('clicked', self._link_clicked_cb, url)
         item.connect('remove_link', self._link_removed_cb)
+        item.notes_changed_signal.connect(self.__link_notes_changed)
         # use index to add to the tray
         self._tray.add_item(item, index)
         item.show()
@@ -628,6 +632,9 @@ class WebActivity(activity.Activity):
             self._view_toolbar.traybutton.props.sensitive = False
             self._view_toolbar.traybutton.props.active = False
             self._view_toolbar.update_traybutton_tooltip()
+
+    def __link_notes_changed(self, button, hash, notes):
+        self.model.change_link_notes(hash, notes)
 
     def _link_clicked_cb(self, button, url):
         ''' an item of the link tray has been clicked '''


### PR DESCRIPTION
* Use the sugar palette system - not the Gtk.Menu system
* Add a textbox so users can take notes on the site they bookmarked (eg. why they bookmarked it, label the bias of each page as a class activity, IDK)

These are patches for WebKit1.  WebKit2 is a massive time sink :smile: - it's nice to do something productive.