### PR TITLE
workaround for rachel.worldpossible.org, for discussion only

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -300,6 +300,15 @@ class TabbedView(BrowserNotebook):
                     WebKit.LoadStatus.FINISHED:
                 tab_page.cancel_download()
 
+        # ensure that a tab opened because of click on 
+        # <a href="something" target="name">this</a>
+        # can be closed and then opened again
+        # (WebKit is keeping the WebView object alive)
+        tab_page.props.browser.destroy()
+
+        # FIXME: above causes log warnings about signal handlers that
+        # were connected to the destroyed WebView object.
+
         self.remove_page(self.page_num(tab_page))
 
         current_page = self.get_nth_page(self.get_current_page())

--- a/pdfviewer.py
+++ b/pdfviewer.py
@@ -303,6 +303,9 @@ class DummyBrowser(GObject.GObject):
     def grab_focus(self):
         pass
 
+    def destroy(self):
+        pass
+
 
 class PDFProgressMessageBox(Gtk.EventBox):
     def __init__(self, message, button_callback):


### PR DESCRIPTION
**Problem**: when a page requests open new window by name, and a window of the same name has been opened and closed already, the new window will not be opened.

**Workaround**: stop and restart Browse.

**Workaround**: right-click and choose "Follow link in new tab".

**Workaround**: change the web content to use target="_blank" or no target attribute.

**Diagnosis**: WebKit keeps a list of browser windows by name, and is not told by Browse that the WebView has been closed.

**Solution**: destroy the WebView instance.

Causes new problem of log noise:

```
/home/olpc/Activities/Browse.activity/browser.py:104: Warning: gsignal.c:2576: 
instance `0x9e2d678' has no handler with id `4631'
  self._browser.disconnect(self._load_status_changed_hid)
/home/olpc/Activities/Browse.activity/webtoolbar.py:477: Warning: gsignal.c:2576: 
instance `0x9e2d678' has no handler with id `4632'
  self._browser.disconnect(self._uri_changed_hid)
/home/olpc/Activities/Browse.activity/webtoolbar.py:478: Warning: gsignal.c:2576: 
instance `0x9e2d678' has no handler with id `4633'
  self._browser.disconnect(self._progress_changed_hid)
/home/olpc/Activities/Browse.activity/webtoolbar.py:479: Warning: gsignal.c:2576: 
instance `0x9e2d678' has no handler with id `4634'
  self._browser.disconnect(self._loading_changed_hid)
/home/olpc/Activities/Browse.activity/webtoolbar.py:480: Warning: gsignal.c:2576: 
instance `0x9e2d678' has no handler with id `4635'
  self._browser.disconnect(self._security_status_changed_hid)
/home/olpc/Activities/Browse.activity/edittoolbar.py:90: Warning: gsignal.c:2576: 
instance `0x9e2d678' has no handler with id `4636'
  self._browser.disconnect(self._selection_changed_hid)
```

**Original problem report**:

The issue is that if you have a web page open and click on a link that launches a second tab, then go to the new tab and close it, then you will not be able to open a new tab from such a link again.

Closing and restarting the Browser activity restores correct operation, until you close the new tab again.

This only happens in the Browser under Sugar; it works correctly under Gnome.

This is an issue because we have deployed RACHEL servers in many of the schools, and the RACHEL main page launches a new tab when you select an item from the home page.

The idea is that a student selects an item, a new tab opens, and when they are finished with it, closes the tab, which then leaves them back at the main page.  This makes navigation easy for students as the main page is always open in its own tab.

The incorrect operation is causing confusion for the students.

You can demonstrate the problem online by pointing the Browser under Sugar to:

http://rachel.worldpossible.org//

then scrolling down and selecting the Infonet or Practical Action item.  *(@quozl adds: or just the first MedlinePlus Medical Encyclopedia index link A-Aq)*

A new tab will open. Change to the new tab and close it.  This will take you back to the main RACHEL screen.  Click on the Infonet or Practical Action item and nothing happens.

If you right-click and select "Follow link in new tab" a new tab will open.
