### PR TITLE
Prevent closing the last non-PDF tab

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -333,13 +333,22 @@ class TabbedView(BrowserNotebook):
             label.update_size(tab_new_size)
 
     def _update_closing_buttons(self):
-        """Prevent closing the last tab."""
-        first_page = self.get_nth_page(0)
-        first_label = self.get_tab_label(first_page)
-        if self.get_n_pages() == 1:
-            first_label.hide_close_button()
+        """Prevent closing the last non-PDF tab"""
+        pages_html = []
+        pages_pdf = []
+        for page_idx in range(self.get_n_pages()):
+            page = self.get_nth_page(page_idx)
+            if isinstance(page, PDFTabPage):
+                pages_pdf.append(page)
+            else:
+                pages_html.append(page)
+
+        if len(pages_html) == 1:
+            for page in pages_html:
+                self.get_tab_label(page).hide_close_button()
         else:
-            first_label.show_close_button()
+            for page in pages_pdf + pages_html:
+                self.get_tab_label(page).show_close_button()
 
     def load_homepage(self, ignore_gconf=False):
         browser = self.current_browser


### PR DESCRIPTION
Fixes a problem: with one HTML tab and one PDF tab shown, close the HTML
tab, and the activity will be left unusable.