### PR TITLE
Port load/read file to webkit2

### DIFF
--- a/pdfviewer.py
+++ b/pdfviewer.py
@@ -237,6 +237,9 @@ class DummyBrowser(GObject.GObject):
         else:
             raise AttributeError('Unknown property %s' % prop.name)
 
+    def get_state(self):
+        return {'uri': self.props.uri, 'title': self.props.title}
+
     def get_title(self):
         return self._title
 
@@ -249,7 +252,7 @@ class DummyBrowser(GObject.GObject):
     def emit_close_tab(self):
         self.emit('tab-close', self._tab)
 
-    def get_history(self):
+    def get_legacy_history(self):
         return [{'url': self.props.uri, 'title': self.props.title}]
 
     def can_undo(self):
@@ -401,7 +404,7 @@ class PDFTabPage(Gtk.HBox):
     When the file is remote, display a message while downloading.
 
     """
-    def __init__(self):
+    def __init__(self, state=None):
         GObject.GObject.__init__(self)
         self._browser = DummyBrowser(self)
         self._message_box = None
@@ -410,6 +413,8 @@ class PDFTabPage(Gtk.HBox):
         self._requested_uri = None
         self._download = None
         self._downloaded_pdf = False
+        if state is not None:
+            self.setup(state['uri'], state['title'])
 
     def setup(self, requested_uri, title=None):
         self._requested_uri = requested_uri

--- a/webactivity.py
+++ b/webactivity.py
@@ -407,14 +407,19 @@ class WebActivity(activity.Activity):
                                       link['color'], link['title'],
                                       link['owner'], -1, link['hash'])
             logging.debug('########## reading %s', data)
-            self._tabbed_view.set_history(self.model.data['history'])
-            for number, tab in enumerate(self.model.data['currents']):
-                tab_page = self._tabbed_view.get_nth_page(number)
-                tab_page.browser.set_history_index(tab['history_index'])
-                zoom_level = tab.get('zoom_level')
-                if zoom_level is not None:
-                    tab_page.browser.set_zoom_level(zoom_level)
-                tab_page.browser.grab_focus()
+            if 'session_state' in self.model.data:
+                self._tabbed_view.set_session_state(
+                    self.model.data['session_state'])
+            else:
+                self._tabbed_view.set_legacy_history(
+                    self.model.data['history'],
+                    self.model.data['currents'])
+                for number, tab in enumerate(self.model.data['currents']):
+                    tab_page = self._tabbed_view.get_nth_page(number)
+                    zoom_level = tab.get('zoom_level')
+                    if zoom_level is not None:
+                        tab_page.browser.set_zoom_level(zoom_level)
+                    tab_page.browser.grab_focus()
 
             self._tabbed_view.set_current_page(self.model.data['current_tab'])
 
@@ -445,7 +450,7 @@ class WebActivity(activity.Activity):
                 else:
                     self.metadata['title'] = browser.props.title
 
-            self.model.data['history'] = self._tabbed_view.get_history()
+            self.model.data['history'] = self._tabbed_view.get_legacy_history()
             current_tab = self._tabbed_view.get_current_page()
             self.model.data['current_tab'] = current_tab
 
@@ -461,6 +466,9 @@ class WebActivity(activity.Activity):
                             'zoom_level': n_browser.get_zoom_level()}
 
                     self.model.data['currents'].append(info)
+
+            self.model.data['session_state'] = \
+                self._tabbed_view.get_state()
 
             f = open(file_path, 'w')
             try:


### PR DESCRIPTION
This requires using the new session state APIs.  We can maintain
backwards compatibility in the form of writing the old format
history and in the form of reading the current url from an old
format history.  However, the code prefers to load from the new
session state format rather than the old format (because it will
put both into a file for backwards compat).

This requires 2.11.3+ (for session state apis).  It seems to work
on 2.11.5, but it is hard to test due to the lack of general stability
in that release.