### PR TITLE
Allow adding bookmarks for PDF pages

### DIFF
--- a/pdfviewer.py
+++ b/pdfviewer.py
@@ -306,6 +306,9 @@ class DummyBrowser(GObject.GObject):
     def destroy(self):
         pass
 
+    def get_window(self):
+        return self._tab.get_window()
+
 
 class PDFProgressMessageBox(Gtk.EventBox):
     def __init__(self, message, button_callback):

--- a/webtoolbar.py
+++ b/webtoolbar.py
@@ -587,7 +587,6 @@ class PrimaryToolbar(ToolbarBase):
         self._forward.props.sensitive = can_go_forward
 
         is_webkit_browser = isinstance(self._browser, Browser)
-        self._link_add.props.sensitive = is_webkit_browser
         self._go_home.props.sensitive = is_webkit_browser
         if is_webkit_browser:
             self._reload_session_history()
@@ -650,7 +649,8 @@ class PrimaryToolbar(ToolbarBase):
 
     def _set_sensitive(self, value):
         for widget in self.toolbar:
-            if widget != self._stop_button:
+            if widget not in (self._stop_button,
+                              self._link_add):
                 widget.set_sensitive(value)
 
     def _reload_session_history(self):


### PR DESCRIPTION
Tested against:

* Bookmarking a pdf
* The screenshot includes the pdf contents
* You can click to launch the pdf (only if you are in a webkit tab,
    however, this is the same with webkit links - lack of load_uri
    implimentation in the dummy browser I believe)