### PR TITLE
Bug improve bookmarks management

### DIFF
--- a/bookmarkbutton.py
+++ b/bookmarkbutton.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016  Utkarsh Tiwari
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact information:
+# Utkarsh Tiwari    iamutkarshtiwari@gmail.com
+
+"""
+BETA.
+"""
+
+import logging
+
+from gi.repository import GObject
+from gi.repository import Gtk
+
+from sugar3.graphics import style
+from sugar3.graphics.icon import Icon
+from sugar3.graphics.palette import Palette, ToolInvoker
+
+
+def _add_accelerator(tool_button):
+    if not tool_button.props.accelerator or not tool_button.get_toplevel() or \
+            not tool_button.get_child():
+        return
+
+    # TODO: should we remove the accelerator from the prev top level?
+    if not hasattr(tool_button.get_toplevel(), 'sugar_accel_group'):
+        logging.debug('No Gtk.AccelGroup in the top level window.')
+        return
+
+    accel_group = tool_button.get_toplevel().sugar_accel_group
+    keyval, mask = Gtk.accelerator_parse(tool_button.props.accelerator)
+    # the accelerator needs to be set at the child, so the Gtk.AccelLabel
+    # in the palette can pick it up.
+    accel_flags = Gtk.AccelFlags.LOCKED | Gtk.AccelFlags.VISIBLE
+    tool_button.get_child().add_accelerator('clicked', accel_group,
+                                            keyval, mask, accel_flags)
+
+
+def _hierarchy_changed_cb(tool_button, previous_toplevel):
+    _add_accelerator(tool_button)
+
+
+def setup_accelerator(tool_button):
+    _add_accelerator(tool_button)
+    tool_button.connect('hierarchy-changed', _hierarchy_changed_cb)
+
+
+class BookmarkToolButton(Gtk.ToggleToolButton):
+
+    __gtype_name__ = 'BookmarkToggleToolButton'
+
+    def __init__(self, icon_name=None, xo_color=None):
+        GObject.GObject.__init__(self)
+
+        self._palette_invoker = ToolInvoker(self)
+
+        if icon_name:
+            self.set_icon_name(icon_name)
+            self.icon_name = icon_name
+
+        self.connect('destroy', self.__destroy_cb)
+
+    def __destroy_cb(self, icon):
+        if self._palette_invoker is not None:
+            self._palette_invoker.detach()
+
+    def set_icon_name(self, icon_name):
+        icon = Icon(icon_name=icon_name)
+        self.set_icon_widget(icon)
+        icon.show()
+
+    def get_icon_name(self):
+        if self.props.icon_widget is not None:
+            return self.props.icon_widget.props.icon_name
+        else:
+            return None
+
+    icon_name = GObject.property(type=str, setter=set_icon_name,
+                                 getter=get_icon_name)
+
+    def set_xo_color(self, xo_color=None):
+        if xo_color is None:
+            icon = Icon(icon_name=self.icon_name)
+        else:
+            icon = Icon(icon_name=self.icon_name, xo_color=xo_color,
+                        pixel_size=style.STANDARD_ICON_SIZE)
+
+        self.set_icon_widget(icon)
+        icon.show()
+
+    def create_palette(self):
+        return None
+
+    def get_palette(self):
+        return self._palette_invoker.palette
+
+    def set_palette(self, palette):
+        self._palette_invoker.palette = palette
+
+    palette = GObject.property(
+        type=object, setter=set_palette, getter=get_palette)
+
+    def get_palette_invoker(self):
+        return self._palette_invoker
+
+    def set_palette_invoker(self, palette_invoker):
+        self._palette_invoker.detach()
+        self._palette_invoker = palette_invoker
+
+    palette_invoker = GObject.property(
+        type=object, setter=set_palette_invoker, getter=get_palette_invoker)
+
+    def set_tooltip(self, text):
+        self.set_palette(Palette(text))
+
+    def set_accelerator(self, accelerator):
+        self._accelerator = accelerator
+        setup_accelerator(self)
+
+    def get_accelerator(self):
+        return self._accelerator
+
+    accelerator = GObject.property(type=str, setter=set_accelerator,
+                                   getter=get_accelerator)
+
+    def do_draw(self, cr):
+        if self.palette and self.palette.is_up():
+            allocation = self.get_allocation()
+            # draw a black background, has been done by the engine before
+            cr.set_source_rgb(0, 0, 0)
+            cr.rectangle(0, 0, allocation.width, allocation.height)
+            cr.paint()
+
+        Gtk.ToggleToolButton.do_draw(self, cr)
+
+        if self.palette and self.palette.is_up():
+            invoker = self.palette.props.invoker
+            invoker.draw_rectangle(cr, self.palette)
+
+        return False
+
+    def do_clicked(self):
+        if self.palette:
+            self.palette.popdown(True)
+
+    palette = property(get_palette, set_palette)

--- a/viewtoolbar.py
+++ b/viewtoolbar.py
@@ -64,14 +64,6 @@ class ViewToolbar(Gtk.Toolbar):
         self.insert(self.fullscreen, -1)
         self.fullscreen.show()
 
-        self.traybutton = ToggleToolButton('tray-show')
-        self.traybutton.set_icon_name('tray-favourite')
-        self.traybutton.connect('toggled', self.__tray_toggled_cb)
-        self.traybutton.props.sensitive = False
-        self.traybutton.props.active = False
-        self.insert(self.traybutton, -1)
-        self.traybutton.show()
-
         tabbed_view = self._activity.get_canvas()
 
         if tabbed_view.get_n_pages():
@@ -106,16 +98,3 @@ class ViewToolbar(Gtk.Toolbar):
 
     def __fullscreen_clicked_cb(self, button):
         self._activity.fullscreen()
-
-    def __tray_toggled_cb(self, button):
-        if button.props.active:
-            self._activity.tray.show()
-        else:
-            self._activity.tray.hide()
-        self.update_traybutton_tooltip()
-
-    def update_traybutton_tooltip(self):
-        if not self.traybutton.props.active:
-            self.traybutton.set_tooltip(_('Show Tray'))
-        else:
-            self.traybutton.set_tooltip(_('Hide Tray'))

--- a/webactivity.py
+++ b/webactivity.py
@@ -174,13 +174,14 @@ class WebActivity(activity.Activity):
         self._tabbed_view.connect('switch-page', self.__switch_page_cb)
 
         self._tray = HTray()
+        self._tray._add_bookmark.connect('add-link', self._link_add_button_cb)
         self.set_tray(self._tray, Gtk.PositionType.BOTTOM)
 
         self._primary_toolbar = PrimaryToolbar(self._tabbed_view, self)
         self._edit_toolbar = EditToolbar(self)
         self._view_toolbar = ViewToolbar(self)
 
-        self._primary_toolbar.connect('add-link', self._link_add_button_cb)
+        self._primary_toolbar.connect('toggle-tray', self._toggle_tray_cb)
 
         self._primary_toolbar.connect('go-home', self._go_home_button_cb)
 
@@ -189,6 +190,8 @@ class WebActivity(activity.Activity):
         self._primary_toolbar.connect('set-home', self._set_home_button_cb)
 
         self._primary_toolbar.connect('reset-home', self._reset_home_button_cb)
+
+        self._primary_toolbar.connect('page-loaded', self._bookmark_color_change_cb)
 
         self._edit_toolbar_button = ToolbarButton(
             page=self._edit_toolbar, icon_name='toolbar-edit')
@@ -471,6 +474,13 @@ class WebActivity(activity.Activity):
             finally:
                 f.close()
 
+    # Toggles the bookmark tray
+    def _toggle_tray_cb(self, button):
+        if self._primary_toolbar._link_add.props.active:
+            self._tray.show()
+        else:
+            self._tray.hide()
+
     def _link_add_button_cb(self, button):
         self._add_link()
 
@@ -487,6 +497,21 @@ class WebActivity(activity.Activity):
     def _reset_home_button_cb(self, button):
         self._tabbed_view.reset_homepage()
         self._alert(_('The default initial page was configured'))
+
+    def _bookmark_color_change_cb(self, button):
+        ''' changes the bookmark color to xo_color/None on page load '''
+        browser = self._tabbed_view.props.current_browser
+        ui_uri = browser.get_uri()
+        if ui_uri is not None:
+            for link in self.model.data['shared_links']:
+                if link['hash'] == sha1(ui_uri).hexdigest():
+                    _logger.debug('_add_link: link exist already a=%s b=%s',
+                                  link['hash'], sha1(ui_uri).hexdigest())
+                    color = profile.get_color()
+                    self._primary_toolbar._link_add.set_xo_color(xo_color=color)
+                    return
+
+        self._primary_toolbar._link_add.set_xo_color(None)
 
     def _alert(self, title, text=None):
         alert = NotifyAlert(timeout=5)
@@ -587,26 +612,25 @@ class WebActivity(activity.Activity):
 
     def _add_link(self):
         ''' take screenshot and add link info to the model '''
-
         browser = self._tabbed_view.props.current_browser
         ui_uri = browser.get_uri()
+        if ui_uri is not None:
+            for link in self.model.data['shared_links']:
+                if link['hash'] == sha1(ui_uri).hexdigest():
+                    _logger.debug('_add_link: link exist already a=%s b=%s',
+                                  link['hash'], sha1(ui_uri).hexdigest())
+                    return
+            buf = self._get_screenshot()
+            timestamp = time.time()
+            self.model.add_link(ui_uri, browser.props.title, buf,
+                                profile.get_nick_name(),
+                                profile.get_color().to_string(), timestamp)
 
-        for link in self.model.data['shared_links']:
-            if link['hash'] == sha1(ui_uri).hexdigest():
-                _logger.debug('_add_link: link exist already a=%s b=%s',
-                              link['hash'], sha1(ui_uri).hexdigest())
-                return
-        buf = self._get_screenshot()
-        timestamp = time.time()
-        self.model.add_link(ui_uri, browser.props.title, buf,
-                            profile.get_nick_name(),
-                            profile.get_color().to_string(), timestamp)
-
-        if self.messenger is not None:
-            self.messenger._add_link(ui_uri, browser.props.title,
-                                     profile.get_color().to_string(),
-                                     profile.get_nick_name(),
-                                     base64.b64encode(buf), timestamp)
+            if self.messenger is not None:
+                self.messenger._add_link(ui_uri, browser.props.title,
+                                         profile.get_color().to_string(),
+                                         profile.get_nick_name(),
+                                         base64.b64encode(buf), timestamp)
 
     def _add_link_model_cb(self, model, index):
         ''' receive index of new link from the model '''
@@ -615,6 +639,8 @@ class WebActivity(activity.Activity):
                               link['color'], link['title'],
                               link['owner'], index, link['hash'],
                               link.get('notes'))
+        color = profile.get_color()
+        self._primary_toolbar._link_add.set_xo_color(xo_color=color)
 
     def _add_link_totray(self, url, buf, color, title, owner, index, hash,
                          notes=None):
@@ -626,18 +652,11 @@ class WebActivity(activity.Activity):
         # use index to add to the tray
         self._tray.add_item(item, index)
         item.show()
-        self._view_toolbar.traybutton.props.sensitive = True
-        self._view_toolbar.traybutton.props.active = True
-        self._view_toolbar.update_traybutton_tooltip()
 
     def _link_removed_cb(self, button, hash):
         ''' remove a link from tray and delete it in the model '''
         self.model.remove_link(hash)
         self._tray.remove_item(button)
-        if len(self._tray.get_children()) == 0:
-            self._view_toolbar.traybutton.props.sensitive = False
-            self._view_toolbar.traybutton.props.active = False
-            self._view_toolbar.update_traybutton_tooltip()
 
     def __link_notes_changed(self, button, hash, notes):
         self.model.change_link_notes(hash, notes)

--- a/webactivity.py
+++ b/webactivity.py
@@ -657,6 +657,7 @@ class WebActivity(activity.Activity):
         ''' remove a link from tray and delete it in the model '''
         self.model.remove_link(hash)
         self._tray.remove_item(button)
+        self._bookmark_color_change_cb(button)
 
     def __link_notes_changed(self, button, hash, notes):
         self.model.change_link_notes(hash, notes)


### PR DESCRIPTION
This PR fixes this defect-> https://bugs.sugarlabs.org/ticket/4714

This patch implements the ```Option 1``` feature mention on the bug^ page. AS mentioned, the ```star``` will now ```only toggle``` the bookmark tray and the pages can be added to the tray by clicking the ```plus``` button added to the tray. The ```color``` of the ```star``` changes to the ```profile_xo_color``` if the page is added to favourites else if the page is ```removed/does-not-exist``` in the tray then color changes to ```default b/w```.  
Here is a gif to demonstrate the feature.
![desktop-animation](https://cloud.githubusercontent.com/assets/6258810/13571167/2cc071e6-e499-11e5-82f8-e624db7209be.gif)

In case if the tray is full of a list of pages which needs scrolling, the scroll buttons can be activated by simply clicking on the ```plus``` icon in the tray which expands to show the ```left/right``` scroll icons and the page can be then added by again clicking over the ```plus``` button.
Here is a gif to demonstrate this feature.
![desktop-animation2](https://cloud.githubusercontent.com/assets/6258810/13571279/fc5fca0a-e499-11e5-977a-a74e0fdc1ca8.gif)
