### PR TITLE
Browse: Improve autocomplete list #4081

### DIFF
--- a/places.py
+++ b/places.py
@@ -34,7 +34,7 @@ class Place(object):
 
 
 class SqliteStore(object):
-    MAX_SEARCH_MATCHES = 7
+    MAX_SEARCH_MATCHES = 20
     EXPIRE_DAYS = 30
 
     def __init__(self):


### PR DESCRIPTION
This patch fixes this defect -> https://bugs.sugarlabs.org/ticket/4081

With this PR ->

1- autocomplete list will now be able to display list of 20(max) entries which can be scrolled with both mouse pointer and Up/Down arrow keys. 
2- URL is now placed below the Url title so that more text is visible.
3- The visible length of the list is of 5 entries so it won't  also not superimpose over the OSK. 

@samdroid-apps Please review it and let me know if any further modification are required. :) 
![desktop-animation](https://cloud.githubusercontent.com/assets/6258810/13524722/f89e2cb4-e222-11e5-8c42-9eb4ed102039.gif)
