### PR TITLE
Fix error when the backup_url value is None

### DIFF
--- a/webactivity.py
+++ b/webactivity.py
@@ -94,7 +94,7 @@ def _seed_xs_cookie(cookie_jar):
     """
     client = GConf.Client.get_default()
     backup_url = client.get_string('/desktop/sugar/backup_url')
-    if backup_url == '':
+    if not backup_url:
         _logger.debug('seed_xs_cookie: Not registered with Schoolserver')
         return
 


### PR DESCRIPTION
I tried to run the Browse activity outside of Sugar, but it fails to run:
```
Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 220, in <module>
    main()
  File "/usr/bin/sugar-activity", line 215, in main
    instance = create_activity_instance(activity_constructor, activity_handle)
  File "/usr/bin/sugar-activity", line 48, in create_activity_instance
    activity = constructor(handle)
  File "/usr/share/sugar/activities/Browse.activity/webactivity.py", line 167, in __init__
    _seed_xs_cookie(cookie_jar)
  File "/usr/share/sugar/activities/Browse.activity/webactivity.py", line 116, in _seed_xs_cookie
    'pkey_hash': sha1(pubkey).hexdigest()}
TypeError: sha1() argument 1 must be string or buffer, not None
```
This patch fixes the problem for me.