### PR TITLE
Preserve old Content-Type behaviour for bundles

### DIFF
--- a/downloadmanager.py
+++ b/downloadmanager.py
@@ -27,6 +27,7 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import GObject
+from gi.repository import Gio
 
 from sugar3.datastore import datastore
 from sugar3 import profile
@@ -214,6 +215,11 @@ class Download(object):
         self.dl_jobject.file_path = self._dest_path
 
         mime_type = download.get_response().get_mime_type()
+
+        if self._source.startswith('http://activities.sugarlabs.org'):
+            if mime_type == 'application/octet-stream':
+                mime_type = Gio.content_type_guess(self._dest_path)[0]
+
         self.dl_jobject.metadata['mime_type'] = mime_type
 
         if mime_type in ('image/bmp', 'image/gif', 'image/jpeg',


### PR DESCRIPTION
Problem: bundles downloaded with Mime-Type of application/octet-stream instead of application/vnd.olpc-sugar; breaking use of activities.sugarlabs.org.  #48 

Solution: detect downloads and change Mime-Type.

Regression introduced in Browse-200, did not occur in Browse-157.3.