### PR TITLE
Fix ctrl+c and ctrl+v

### DIFF
--- a/webactivity.py
+++ b/webactivity.py
@@ -413,55 +413,64 @@ class WebActivity(activity.Activity):
         self.remove_alert(alert)
 
     def _key_press_cb(self, widget, event):
-        key_name = Gdk.keyval_name(event.keyval)
         browser = self._tabbed_view.props.current_browser
 
         if event.get_state() & Gdk.ModifierType.CONTROL_MASK:
-            if key_name == 'f':
-                _logger.debug('keyboard: Find')
+            if event.keyval == Gdk.KEY_f:
                 self._edit_toolbar_button.set_expanded(True)
                 self._edit_toolbar.search_entry.grab_focus()
-            elif key_name == 'l':
-                _logger.debug('keyboard: Focus url entry')
+                return True
+            if event.keyval == Gdk.KEY_l:
                 self._primary_toolbar.entry.grab_focus()
-            elif key_name == 'minus':
-                _logger.debug('keyboard: Zoom out')
-                browser.zoom_out()
-            elif key_name == 'equal':
-                # Equal is + without a shift, a convenience in addition to
-                # the ctrl+ accelerator configured in the ToolButton
-                _logger.debug('keyboard: Zoom in')
+                return True
+            if event.keyval == Gdk.KEY_equal:
+                # On US keyboards, KEY_equal is KEY_plus without
+                # SHIFT_MASK, so for convenience treat this as the
+                # same as the zoom in accelerator configured in
+                # WebKit2
                 browser.zoom_in()
-            elif Gdk.keyval_name(event.keyval) == "t":
+                return True
+            if event.keyval == Gdk.KEY_t:
                 self._tabbed_view.add_tab()
-            elif key_name == 'w':
-                _logger.debug('keyboard: close tab')
+                return True
+            if event.keyval == Gdk.KEY_w:
                 self._tabbed_view.close_tab()
-            else:
-                return False
+                return True
 
-            return True
+            # FIXME: copy and paste is supposed to be handled by
+            # Gtk.Entry, but does not work when we catch
+            # key-press-event and return False.
+            if self._primary_toolbar.entry.is_focus():
+                if event.keyval == Gdk.KEY_c:
+                    self._primary_toolbar.entry.copy_clipboard()
+                    return True
+                if event.keyval == Gdk.KEY_v:
+                    self._primary_toolbar.entry.paste_clipboard()
+                    return True
 
-        elif key_name in ('KP_Up', 'KP_Down', 'KP_Left', 'KP_Right'):
+            return False
+
+        if event.keyval in (Gdk.KEY_KP_Up, Gdk.KEY_KP_Down,
+                            Gdk.KEY_KP_Left, Gdk.KEY_KP_Right):
             scrolled_window = browser.get_parent()
 
-            if key_name in ('KP_Up', 'KP_Down'):
+            if event.keyval in (Gdk.KEY_KP_Up, Gdk.KEY_KP_Down):
                 adjustment = scrolled_window.get_vadjustment()
-            elif key_name in ('KP_Left', 'KP_Right'):
+            elif event.keyval in (Gdk.KEY_KP_Left, Gdk.KEY_KP_Right):
                 adjustment = scrolled_window.get_hadjustment()
             value = adjustment.get_value()
             step = adjustment.get_step_increment()
 
-            if key_name in ('KP_Up', 'KP_Left'):
+            if event.keyval in (Gdk.KEY_KP_Up, Gdk.KEY_KP_Left):
                 adjustment.set_value(value - step)
-            elif key_name in ('KP_Down', 'KP_Right'):
+            else:
                 adjustment.set_value(value + step)
 
             return True
 
-        elif key_name == 'Escape':
-            _logger.debug('keyboard: Stop loading')
+        if event.keyval == Gdk.KEY_Escape:
             browser.stop_loading()
+            return True
 
         return False
 

--- a/webtoolbar.py
+++ b/webtoolbar.py
@@ -225,12 +225,10 @@ class WebEntry(iconentry.IconEntry):
             self.activate(uri)
 
     def __key_press_event_cb(self, entry, event):
-        keyname = Gdk.keyval_name(event.keyval)
-
         selection = self._search_view.get_selection()
         model, selected = selection.get_selected()
 
-        if keyname == 'Up':
+        if event.keyval == Gdk.KEY_uparrow:
             if selected is None:
                 selection.select_iter(model[-1].iter)
                 self._set_text(model[-1][0])
@@ -241,7 +239,8 @@ class WebEntry(iconentry.IconEntry):
                     self._set_text(model.get(up_iter, self._COL_ADDRESS)[0])
             self.set_vadjustments(selection)
             return True
-        elif keyname == 'Down':
+
+        if event.keyval == Gdk.KEY_downarrow:
             if selected is None:
                 down_iter = model.get_iter_first()
             else:
@@ -251,16 +250,19 @@ class WebEntry(iconentry.IconEntry):
                 self._set_text(model.get(down_iter, self._COL_ADDRESS)[0])
             self.set_vadjustments(selection)
             return True
-        elif keyname == 'Return':
+
+        if event.keyval == Gdk.KEY_Return:
             if selected is None:
                 return False
             uri = model[model.get_path(selected)][self._COL_ADDRESS]
             self.activate(uri)
             return True
-        elif keyname == 'Escape':
+
+        if event.keyval == Gdk.KEY_Escape:
             self._search_window.hide()
             self.props.text = ''
             return True
+
         return False
 
     def set_vadjustments(self, selection):


### PR DESCRIPTION
Problem: `ctrl+c` and `ctrl+v` do not work in the URL entry, but emit an alert sound.

Analysis: the `key-press-event` handlers for the activity, the toolbar, and the entry widget are coded to pass unhandled events to the `Gtk.Entry` widget, and this happens properly when sugar3.IconEntry is used with the example, but not when used with the activity.  Cause unknown.

Solution: explicitly handle the `ctrl+c` and `ctrl+v` events.

References:
https://bugs.sugarlabs.org/ticket/4979
https://bugs.sugarlabs.org/ticket/4642

[explicit handling of events]
Written-by: GAURAV MISHRA <gauravm043@gmail.com>

[test, review, and switch to Gdk.KEY_* constants]
Signed-off-by: James Cameron <quozl@laptop.org>