### PR TITLE
[Fix]: #55 Reset tab title after a resource download request

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -606,6 +606,8 @@ class TabLabel(Gtk.HBox):
             if widget.props.title is None:
                 self._label.set_text(_('Untitled'))
                 self._title = _('Untitled')
+            else:
+                self._label.set_text(self._title)
         else:
             self._label.set_text(_('Loading...'))
 


### PR DESCRIPTION
**Fixed in this PR:** #55

**Tested on:** 
 - Ubuntu 16.04, rdesktop, Sugar 0.112

@quozl, kindly review