### PR TITLE
Port from GConf to Gio.Settings using staged release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+202
+
+* Stop using GConf for settings (James Cameron),
+
 201.5
 
 * Add README.md documentation for activity (James Cameron),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+201.5
+
+* Add README.md documentation for activity (James Cameron),
+* Detect and avoid Fedora 18 systems (James Cameron),
+* Hide notebook tabs in fullscreen mode (Rahul Bothra),
+* Reset tab title after a download starts (Rahul Bothra),
+* Fix log errors when a PDF is shown (Rahul Bothra, James Cameron),
+* Begin saving home-page in Gio.Settings (James Cameron),
+* Update POT file with new strings (James Cameron),
+* Updated translations (Chris Leonard et al),
+
 201.4
 
 * Source formatting to flake8 (James Cameron),

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ On Fedora systems;
 dnf install sugar-browse
 ```
 
-Browse depends on Python, [Sugar Toolkit](https://github.com/sugarlabs/sugar-toolkit-gtk3), D-Bus, Cairo, Telepathy, GTK+ 3, GConf, Pango, Rsvg, Soup, Evince and WebKit.
+Browse depends on Python, [Sugar Toolkit](https://github.com/sugarlabs/sugar-toolkit-gtk3), D-Bus, Cairo, Telepathy, GTK+ 3, Pango, Rsvg, Soup, Evince and WebKit.
 
 Browse is started by [Sugar](https://github.com/sugarlabs/sugar).
 

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,6 +1,6 @@
 [Activity]
 name = Browse
-activity_version = 201.4
+activity_version = 201.5
 bundle_id = org.laptop.WebActivity
 icon = activity-web
 exec = sugar-activity webactivity.WebActivity -s

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,6 +1,6 @@
 [Activity]
 name = Browse
-activity_version = 201.5
+activity_version = 202
 bundle_id = org.laptop.WebActivity
 icon = activity-web
 exec = sugar-activity webactivity.WebActivity -s

--- a/browser.py
+++ b/browser.py
@@ -75,7 +75,7 @@ TAB_PDF = 'pdf'
 _sugar_version = None
 
 
-def get_sugar_version():
+def _get_sugar_version():
     global _sugar_version
     if _sugar_version is None:
         if 'SUGAR_VERSION' in os.environ:
@@ -627,7 +627,7 @@ class Browser(WebKit2.WebView):
                                     ([])),
     }
 
-    CURRENT_SUGAR_VERSION = get_sugar_version()
+    CURRENT_SUGAR_VERSION = _get_sugar_version()
 
     SECURITY_STATUS_SECURE = 1
     SECURITY_STATUS_INSECURE = 2

--- a/browser.py
+++ b/browser.py
@@ -30,7 +30,6 @@ from gi.repository import Gdk
 from gi.repository import Pango
 from gi.repository import WebKit2
 from gi.repository import Soup
-from gi.repository import GConf
 from gi.repository import Gio
 
 from sugar3.activity.activity import get_bundle_path, get_activity_root
@@ -68,7 +67,6 @@ _HOSTNAME_REGEX = re.compile('[a-z]+://([^/]+)/.*')
 DEFAULT_ERROR_PAGE = os.path.join(get_bundle_path(),
                                   'data/error_page.tmpl')
 
-HOME_PAGE_GCONF_KEY = '/desktop/sugar/browser/home_page'
 SETTINGS_SCHEMA_ID = 'org.laptop.WebActivity'
 SETTINGS_KEY_HOME_PAGE = 'home-page'
 
@@ -432,14 +430,13 @@ class TabbedView(BrowserNotebook):
             for page in pages_pdf + pages_html:
                 self.get_tab_label(page).show_close_button()
 
-    def load_homepage(self, ignore_gconf=False):
+    def load_homepage(self, ignore_settings=False):
         browser = self.current_browser
-        uri_homepage = None
-        if not ignore_gconf:
-            client = GConf.Client.get_default()
-            uri_homepage = client.get_string(HOME_PAGE_GCONF_KEY)
-        if uri_homepage is not None:
-            browser.load_uri(uri_homepage)
+        home_page = None
+        if not ignore_settings:
+            home_page = self.settings.get_string(SETTINGS_KEY_HOME_PAGE)
+        if home_page != '':
+            browser.load_uri(home_page)
         elif os.path.isfile(LIBRARY_PATH):
             browser.load_uri('file://' + LIBRARY_PATH)
         else:
@@ -450,13 +447,9 @@ class TabbedView(BrowserNotebook):
 
     def set_homepage(self):
         uri = self.current_browser.get_uri()
-        client = GConf.Client.get_default()
-        client.set_string(HOME_PAGE_GCONF_KEY, uri)
         self.settings.set_string(SETTINGS_KEY_HOME_PAGE, uri)
 
     def reset_homepage(self):
-        client = GConf.Client.get_default()
-        client.unset(HOME_PAGE_GCONF_KEY)
         self.settings.reset(SETTINGS_KEY_HOME_PAGE)
 
     def _get_current_browser(self):

--- a/browser.py
+++ b/browser.py
@@ -32,7 +32,7 @@ from gi.repository import WebKit2
 from gi.repository import Soup
 from gi.repository import GConf
 
-from sugar3.activity import activity
+from sugar3.activity.activity import get_bundle_path, get_activity_root
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.alert import Alert, ConfirmationAlert
@@ -64,7 +64,7 @@ _NON_SEARCH_REGEX = re.compile('''
     ''', re.VERBOSE)
 _HOSTNAME_REGEX = re.compile('[a-z]+://([^/]+)/.*')
 
-DEFAULT_ERROR_PAGE = os.path.join(activity.get_bundle_path(),
+DEFAULT_ERROR_PAGE = os.path.join(get_bundle_path(),
                                   'data/error_page.tmpl')
 
 HOME_PAGE_GCONF_KEY = '/desktop/sugar/browser/home_page'
@@ -411,7 +411,7 @@ class TabbedView(BrowserNotebook):
         elif os.path.isfile(LIBRARY_PATH):
             browser.load_uri('file://' + LIBRARY_PATH)
         else:
-            default_page = os.path.join(activity.get_bundle_path(),
+            default_page = os.path.join(get_bundle_path(),
                                         "data/index.html")
             browser.load_uri('file://' + default_page)
         browser.grab_focus()
@@ -752,7 +752,7 @@ class Browser(WebKit2.WebView):
             async_err_cb()
 
         def writer(view, result):
-            temp_path = os.path.join(activity.get_activity_root(), 'instance')
+            temp_path = os.path.join(get_activity_root(), 'instance')
             file_path = os.path.join(temp_path, '%i' % time.time())
 
             file_handle = file(file_path, 'w')
@@ -848,7 +848,7 @@ class Browser(WebKit2.WebView):
                 WebKit2.PolicyError.FRAME_LOAD_INTERRUPTED_BY_POLICY_CHANGE,
                 WebKit2.PluginError.WILL_HANDLE_LOAD):
             if self._inject_media_style:
-                css_style_file = open(os.path.join(activity.get_bundle_path(),
+                css_style_file = open(os.path.join(get_bundle_path(),
                                                    "data/media-controls.css"))
                 css_style = css_style_file.read().replace('\n', '')
                 inject_style_script = \

--- a/org.laptop.WebActivity.gschema.xml
+++ b/org.laptop.WebActivity.gschema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+    <schema id="org.laptop.WebActivity" path="/org/laptop/WebActivity/">
+        <key name="home-page" type="s">
+            <default>''</default>
+            <summary>Home page URL</summary>
+            <description>URL to show as default or when home buttin is pressed.</description>
+        </key>
+    </schema>
+</schemalist>

--- a/po/Browse.pot
+++ b/po/Browse.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-03 08:03+1100\n"
+"POT-Creation-Date: 2018-03-29 12:40+1100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,60 +56,60 @@ msgid ""
 "collections"
 msgstr ""
 
-#: browser.py:279
+#: browser.py:309
 #, python-format
 msgid "This tab has crashed Browse: %s"
 msgstr ""
 
-#: browser.py:280
+#: browser.py:310
 msgid "If you reopen the tab, it may just crash again"
 msgstr ""
 
-#: browser.py:281
+#: browser.py:311
 msgid "Reopen"
 msgstr ""
 
-#: browser.py:282
+#: browser.py:312
 msgid "Disregard"
 msgstr ""
 
-#: browser.py:562 browser.py:607 browser.py:608 webactivity.py:366
+#: browser.py:589 browser.py:634 browser.py:635 webactivity.py:377
 msgid "Untitled"
 msgstr ""
 
-#: browser.py:610
+#: browser.py:639
 msgid "Loading..."
 msgstr ""
 
-#: browser.py:861 browser.py:862
+#: browser.py:890 browser.py:891
 msgid "This web page could not be loaded"
 msgstr ""
 
-#: browser.py:863
+#: browser.py:892
 #, python-format
 msgid ""
 "\"%s\" could not be loaded. Please check for typing errors, and make sure "
 "you are connected to the Internet."
 msgstr ""
 
-#: browser.py:866 pdfviewer.py:388
+#: browser.py:895 pdfviewer.py:391
 msgid "Try again"
 msgstr ""
 
-#: browser.py:878
+#: browser.py:907
 msgid "access to your location"
 msgstr ""
 
-#: browser.py:881
+#: browser.py:910
 msgid "to display notifications in the frame"
 msgstr ""
 
-#: browser.py:893
+#: browser.py:922
 #, python-format
 msgid "Allow %s to %s?"
 msgstr ""
 
-#: browser.py:896
+#: browser.py:925
 msgid "You can change your choice later by reloading the page"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Download started"
 msgstr ""
 
-#: downloadmanager.py:219 pdfviewer.py:579
+#: downloadmanager.py:219 pdfviewer.py:582
 #, python-format
 msgid "From: %s"
 msgstr ""
@@ -169,11 +169,11 @@ msgid ""
 "%(source)s."
 msgstr ""
 
-#: edittoolbar.py:67
+#: edittoolbar.py:69
 msgid "Previous"
 msgstr ""
 
-#: edittoolbar.py:74
+#: edittoolbar.py:76
 msgid "Next"
 msgstr ""
 
@@ -217,43 +217,43 @@ msgstr ""
 msgid "Copy text"
 msgstr ""
 
-#: pdfviewer.py:94 viewtoolbar.py:39
+#: pdfviewer.py:97 viewtoolbar.py:39
 msgid "Zoom out"
 msgstr ""
 
-#: pdfviewer.py:100 viewtoolbar.py:45
+#: pdfviewer.py:103 viewtoolbar.py:45
 msgid "Zoom in"
 msgstr ""
 
-#: pdfviewer.py:106 viewtoolbar.py:51
+#: pdfviewer.py:109 viewtoolbar.py:51
 msgid "Actual size"
 msgstr ""
 
-#: pdfviewer.py:117
+#: pdfviewer.py:120
 msgid "Previous page"
 msgstr ""
 
-#: pdfviewer.py:124
+#: pdfviewer.py:127
 msgid "Next page"
 msgstr ""
 
-#: pdfviewer.py:136
+#: pdfviewer.py:139
 msgid "Save PDF to Journal"
 msgstr ""
 
-#: pdfviewer.py:335
+#: pdfviewer.py:338
 msgid "Cancel"
 msgstr ""
 
-#: pdfviewer.py:485
+#: pdfviewer.py:488
 msgid "Downloading document..."
 msgstr ""
 
-#: pdfviewer.py:529
+#: pdfviewer.py:532
 msgid "This document could not be loaded"
 msgstr ""
 
-#: pdfviewer.py:537
+#: pdfviewer.py:540
 msgid "Please make sure you are connected to the Internet."
 msgstr ""
 
@@ -269,80 +269,94 @@ msgstr ""
 msgid "Hide Tray"
 msgstr ""
 
-#: webactivity.py:189
+#: webactivity.py:196
 msgid "Bookmarks"
 msgstr ""
 
-#: webactivity.py:413
+#: webactivity.py:424
 msgid "The initial page was configured"
 msgstr ""
 
-#: webactivity.py:417
+#: webactivity.py:428
 msgid "The default initial page was configured"
 msgstr ""
 
-#: webactivity.py:616
+#: webactivity.py:627
 msgid "Download in progress"
 msgid_plural "Downloads in progress"
 msgstr[0] ""
 msgstr[1] ""
 
-#: webactivity.py:619
+#: webactivity.py:630
 msgid "Stopping now will erase your download"
 msgid_plural "Stopping now will erase your downloads"
 msgstr[0] ""
 msgstr[1] ""
 
-#: webactivity.py:624
+#: webactivity.py:635
 msgid "Continue download"
 msgid_plural "Continue downloads"
 msgstr[0] ""
 msgstr[1] ""
 
-#: webactivity.py:629
+#: webactivity.py:640
 msgid "Stop"
 msgstr ""
 
-#: webtoolbar.py:360
+#: webactivity.py:686
+msgid "Activity not compatible with this system."
+msgstr ""
+
+#: webactivity.py:687
+msgid "Please downgrade activity and try again."
+msgstr ""
+
+#: webactivity.py:692
+msgid ""
+"Uh oh, WebKit2 is too old. Browse-200 and later require WebKit2 API 4.0, "
+"sorry!"
+msgstr ""
+
+#: webtoolbar.py:353
 msgid "Show Web Inspector"
 msgstr ""
 
-#: webtoolbar.py:369
+#: webtoolbar.py:362
 msgid "Home page"
 msgstr ""
 
-#: webtoolbar.py:375
+#: webtoolbar.py:368
 msgid "Select as initial page"
 msgstr ""
 
-#: webtoolbar.py:380
+#: webtoolbar.py:373
 msgid "Reset initial page"
 msgstr ""
 
-#: webtoolbar.py:386
+#: webtoolbar.py:379
 msgid "Library"
 msgstr ""
 
-#: webtoolbar.py:426
+#: webtoolbar.py:418
 msgid "Back"
 msgstr ""
 
-#: webtoolbar.py:441
+#: webtoolbar.py:433
 msgid "Forward"
 msgstr ""
 
-#: webtoolbar.py:456 webtoolbar.py:511
+#: webtoolbar.py:448 webtoolbar.py:503
 msgid "No Downloads Running"
 msgstr ""
 
-#: webtoolbar.py:463
+#: webtoolbar.py:455
 msgid "Bookmark"
 msgstr ""
 
-#: webtoolbar.py:507
+#: webtoolbar.py:499
 msgid "{}% Downloaded"
 msgstr ""
 
-#: webtoolbar.py:757
+#: webtoolbar.py:753
 msgid "No Title"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,24 +7,24 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-03-24 17:39+1100\n"
-"PO-Revision-Date: 2008-12-20 00:00-0500\n"
-"Last-Translator: Chris Leonard <cjl@laptop.org>\n"
+"PO-Revision-Date: 2018-02-22 17:39+0000\n"
+"Last-Translator: Yaron <sh.yaron@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=(n != 1);\n"
-"X-Generator: Pootle 1.1.0rc2\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Pootle 2.5.1.1\n"
+"X-POOTLE-MTIME: 1519321143.000000\n"
 
 #: activity/activity.info:2
-#, fuzzy
 msgid "Browse"
-msgstr "דִּיפְדּוּף"
+msgstr "דפדפן"
 
 #: activity/activity.info:3
 msgid "Surf the world!"
-msgstr ""
+msgstr "גלישה ברחבי העולם!"
 
 #: activity/activity.info:4
 msgid ""
@@ -36,7 +36,7 @@ msgstr ""
 
 #: activity/activity.info:4
 msgid "To help in researching, Browse offers many features:"
-msgstr ""
+msgstr "כדי לסייע במחקר, דפדפן מציע מגוון תכונות:"
 
 #: activity/activity.info:4
 msgid ""
@@ -59,31 +59,31 @@ msgstr ""
 #: browser.py:275
 #, python-format
 msgid "This tab has crashed Browse: %s"
-msgstr ""
+msgstr "לשונית זו הקריסה את דפדפן: %s"
 
 #: browser.py:276
 msgid "If you reopen the tab, it may just crash again"
-msgstr ""
+msgstr "פתיחת הלשונית פעם נוספת עלולה להקריס פעם נוספת"
 
 #: browser.py:277
 msgid "Reopen"
-msgstr ""
+msgstr "פתיחה מחדש"
 
 #: browser.py:278
 msgid "Disregard"
-msgstr ""
+msgstr "התעלמות"
 
 #: browser.py:558 browser.py:603 browser.py:604 webactivity.py:351
 msgid "Untitled"
-msgstr ""
+msgstr "ללא שם"
 
 #: browser.py:606
 msgid "Loading..."
-msgstr ""
+msgstr "בטעינה…"
 
 #: browser.py:849 browser.py:850
 msgid "This web page could not be loaded"
-msgstr ""
+msgstr "לא ניתן לטעון את עמוד האינטרנט"
 
 #: browser.py:851
 #, python-format
@@ -91,18 +91,19 @@ msgid ""
 "\"%s\" could not be loaded. Please check for typing errors, and make sure "
 "you are connected to the Internet."
 msgstr ""
+"לא ניתן לטעון את „%s” . נא לבדוק שלא שגית בהקלדה ושיש לך חיבור לאינטרנט."
 
 #: browser.py:854 pdfviewer.py:388
 msgid "Try again"
-msgstr ""
+msgstr "ניסיון חוזר"
 
 #: browser.py:866
 msgid "access to your location"
-msgstr ""
+msgstr "גישה למיקום שלך"
 
 #: browser.py:869
 msgid "to display notifications in the frame"
-msgstr ""
+msgstr "להציג הודעות במסגרת"
 
 #: browser.py:881
 #, python-format
@@ -111,76 +112,73 @@ msgstr ""
 
 #: browser.py:884
 msgid "You can change your choice later by reloading the page"
-msgstr ""
+msgstr "ניתן לשנות את הבחירה שלך מאוחר יותר על ידי רענון העמוד"
 
 #: webactivity.py:183
 msgid "Bookmarks"
-msgstr ""
+msgstr "סימניות"
 
 #: webactivity.py:398
 msgid "The initial page was configured"
-msgstr ""
+msgstr "העמוד הראשוני הוגדר"
 
 #: webactivity.py:402
 msgid "The default initial page was configured"
-msgstr ""
+msgstr "עמוד בררת המחדל הראשוני הוגדר"
 
 #: webactivity.py:592
-#, fuzzy
 msgid "Download in progress"
 msgid_plural "Downloads in progress"
-msgstr[0] "ההורדה בתהליך"
+msgstr[0] "מתבצעת הורדה"
+msgstr[1] "מתבצעות הורדות"
 
 #: webactivity.py:595
-#, fuzzy
 msgid "Stopping now will erase your download"
 msgid_plural "Stopping now will erase your downloads"
-msgstr[0] "עצירה עכשיו תבטל את ההורדה שלך"
+msgstr[0] "עצירה בשלב זה תמחק את ההורדה שלך"
+msgstr[1] "עצירה בשלב זה תמחק את ההורדות שלך"
 
 #: webactivity.py:600
 msgid "Continue download"
 msgid_plural "Continue downloads"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "להמשיך בהורדה"
+msgstr[1] "להמשיך בהורדות"
 
 #: webactivity.py:605
-#, fuzzy
 msgid "Stop"
-msgstr "עצור"
+msgstr "עצירה"
 
 #: webtoolbar.py:360
 msgid "Show Web Inspector"
-msgstr ""
+msgstr "הצגת חוקר העמודים"
 
 #: webtoolbar.py:369
 msgid "Home page"
-msgstr ""
+msgstr "עמוד הבית"
 
 #: webtoolbar.py:375
 msgid "Select as initial page"
-msgstr ""
+msgstr "הגדרה כעמוד ראשוני"
 
 #: webtoolbar.py:380
 msgid "Reset initial page"
-msgstr ""
+msgstr "איפוס העמוד הראשוני"
 
 #: webtoolbar.py:386
 msgid "Library"
-msgstr ""
+msgstr "ספרייה"
 
 #: webtoolbar.py:426
-#, fuzzy
 msgid "Back"
 msgstr "חזרה"
 
 #: webtoolbar.py:441
-#, fuzzy
 msgid "Forward"
 msgstr "קדימה"
 
 #: webtoolbar.py:456 webtoolbar.py:514
 msgid "No Downloads Running"
-msgstr ""
+msgstr "אין הורדות פעילות"
 
 #: webtoolbar.py:463
 #, fuzzy
@@ -193,11 +191,11 @@ msgstr ""
 
 #: webtoolbar.py:762
 msgid "No Title"
-msgstr ""
+msgstr "אין כותרת"
 
 #: downloadmanager.py:140
 msgid "Not enough space to download"
-msgstr ""
+msgstr "אין די מקום להורדה"
 
 #: downloadmanager.py:149
 #, python-brace-format
@@ -207,29 +205,25 @@ msgid ""
 msgstr ""
 
 #: downloadmanager.py:157 downloadmanager.py:241
-#, fuzzy
 msgid "Ok"
 msgstr "אישור"
 
 #: downloadmanager.py:167
-#, fuzzy
 msgid "Download started"
 msgstr "הורדה החלה"
 
 #: downloadmanager.py:211 pdfviewer.py:579
 #, python-format
 msgid "From: %s"
-msgstr ""
+msgstr "מהמיקום: %s"
 
 #: downloadmanager.py:234
-#, fuzzy
 msgid "Download completed"
-msgstr "הורדה הושלמה"
+msgstr "ההורדה הושלמה"
 
 #: downloadmanager.py:238
-#, fuzzy
 msgid "Show in Journal"
-msgstr "הצג ביומן"
+msgstr "הצגה ביומן"
 
 #: downloadmanager.py:333
 #, python-format
@@ -237,83 +231,76 @@ msgid ""
 "Downloading %(filename)s from \n"
 "%(source)s."
 msgstr ""
+"%(filename)s מתקבל מהמיקום \n"
+"%(source)s."
 
 #: edittoolbar.py:67
-#, fuzzy
 msgid "Previous"
-msgstr "קודם"
+msgstr "הקודם"
 
 #: edittoolbar.py:74
-#, fuzzy
 msgid "Next"
 msgstr "הבא"
 
 #: linkbutton.py:133
-#, fuzzy
 msgid "Remove"
-msgstr "הסר"
+msgstr "הסרה"
 
 #: linkbutton.py:152
 msgid "Take notes on this page"
-msgstr ""
+msgstr "כתיבת הערות על העמוד הזה"
 
 #: viewtoolbar.py:39 pdfviewer.py:94
-#, fuzzy
 msgid "Zoom out"
-msgstr "הגדל"
+msgstr "התרחקות"
 
 #: viewtoolbar.py:45 pdfviewer.py:100
-#, fuzzy
 msgid "Zoom in"
-msgstr "הקטן"
+msgstr "התקרבות"
 
 #: viewtoolbar.py:51 pdfviewer.py:106
 msgid "Actual size"
-msgstr ""
+msgstr "גודל מעשי"
 
 #: viewtoolbar.py:62
-#, fuzzy
 msgid "Fullscreen"
 msgstr "מסך מלא"
 
 #: viewtoolbar.py:119
-#, fuzzy
 msgid "Show Tray"
-msgstr "הצג מגש"
+msgstr "הצגת מגש"
 
 #: viewtoolbar.py:121
-#, fuzzy
 msgid "Hide Tray"
-msgstr "הסתר מגש"
+msgstr "הסתרת מגש"
 
 #: pdfviewer.py:117
 msgid "Previous page"
-msgstr ""
+msgstr "העמוד הקודם"
 
 #: pdfviewer.py:124
 msgid "Next page"
-msgstr ""
+msgstr "העמוד הבא"
 
 #: pdfviewer.py:136
 msgid "Save PDF to Journal"
-msgstr ""
+msgstr "שמירת PDF ליומן"
 
 #: pdfviewer.py:335
-#, fuzzy
 msgid "Cancel"
 msgstr "ביטול"
 
 #: pdfviewer.py:485
 msgid "Downloading document..."
-msgstr ""
+msgstr "המסמך מתקבל…"
 
 #: pdfviewer.py:529
 msgid "This document could not be loaded"
-msgstr ""
+msgstr "לא ניתן לטעון את המסמך הזה"
 
 #: pdfviewer.py:537
 msgid "Please make sure you are connected to the Internet."
-msgstr ""
+msgstr "נא לוודא שיש חיבור לאינטרנט."
 
 #: palettes.py:164
 #, fuzzy
@@ -326,24 +313,24 @@ msgstr ""
 
 #: palettes.py:178
 msgid "Keep link"
-msgstr ""
+msgstr "לשמור את הקישור"
 
 #: palettes.py:184
 msgid "Copy link"
-msgstr ""
+msgstr "להעתיק את הקישור"
 
 #: palettes.py:191
 msgid "Copy link text"
-msgstr ""
+msgstr "להעתיק את הטקסט של הקישור"
 
 #: palettes.py:206
 msgid "Copy image"
-msgstr ""
+msgstr "להעתיק תמונה"
 
 #: palettes.py:212
 msgid "Keep image"
-msgstr ""
+msgstr "לשמור תמונה"
 
 #: palettes.py:227
 msgid "Copy text"
-msgstr ""
+msgstr "העתקת טקסט"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: web-activity\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-03-24 17:39+1100\n"
-"PO-Revision-Date: 2017-06-04 01:28+0000\n"
-"Last-Translator: Chris <cjl@sugarlabs.org>\n"
+"PO-Revision-Date: 2018-03-18 03:11+0000\n"
+"Last-Translator: avinashbharti97 <avinashbharti97@gmail.com>\n"
 "Language-Team: Hindi <indlinux-hindi@lists.sourceforge.net>\n"
 "Language: hi\n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.5.1.1\n"
-"X-POOTLE-MTIME: 1496539715.000000\n"
+"X-POOTLE-MTIME: 1521342712.000000\n"
 
 #: activity/activity.info:2
 msgid "Browse"
@@ -40,25 +40,30 @@ msgstr ""
 
 #: activity/activity.info:4
 msgid "To help in researching, Browse offers many features:"
-msgstr ""
+msgstr "शोध में सहायता करने के लिए, ब्राउज़ कई विशेषताएं प्रदान करता है:"
 
 #: activity/activity.info:4
 msgid ""
 "Bookmark (save) good pages you find - never loose good resources or forget "
 "to add them to your bibliography"
 msgstr ""
+"अच्छे पृष्ठों को खोजें (सहेजें) अच्छे पृष्ठ - कभी ढीले अच्छे संसाधन न हों या "
+"उन्हें अपनी ग्रंथसूची में जोड़ना भूल जाएं"
 
 #: activity/activity.info:4
 msgid ""
 "Bookmark pages with collaborators in real time - great for researching as a "
 "group or teachers showing pages to their class"
 msgstr ""
+"रीयल टाइम में सहयोगियों के साथ पृष्ठों को बुकमार्क करें - समूह या शिक्षकों के"
+" रूप में उनकी कक्षा में पृष्ठों को दिखाने वाले शोध के लिए शानदार"
 
 #: activity/activity.info:4
 msgid ""
 "Comment on your bookmarked pages - a great tool for making curated "
 "collections"
 msgstr ""
+"अपने बुकमार्क पृष्ठों पर टिप्पणी - क्युरेटेड संग्रह बनाने के लिए एक महान टूल"
 
 #: browser.py:275
 #, python-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-03-24 17:39+1100\n"
-"PO-Revision-Date: 2016-10-22 17:44+0000\n"
+"PO-Revision-Date: 2018-02-10 11:57+0000\n"
 "Last-Translator: Besnik_b <besnik@programeshqip.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: sq\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.5.1.1\n"
-"X-POOTLE-MTIME: 1477158273.000000\n"
+"X-POOTLE-MTIME: 1518263859.000000\n"
 
 #: activity/activity.info:2
 msgid "Browse"
@@ -24,10 +24,9 @@ msgstr "Shfletoni"
 
 #: activity/activity.info:3
 msgid "Surf the world!"
-msgstr ""
+msgstr "Lundroni nëpër botë!"
 
 #: activity/activity.info:4
-#, fuzzy
 msgid ""
 "Surf the world! Here you can do research, watch educational videos, take "
 "online courses, find books, connect with friends and more.  Browse is "
@@ -35,46 +34,55 @@ msgid ""
 "javascript interpreter - allowing you to view the full beauty of the web."
 msgstr ""
 "Lundroni nëpër botë! Këtu mund të bëni kërkime, të shihni video edukative, "
-"të ndiqni mësime në Internet, të gjeni libra, të lidheni me shokët, etj."
+"të ndiqni mësime në Internet, të gjeni libra, të lidheni me shokët, etj. "
+"Shfletoni bazohet në mekanizmin WebKit2 për vizatim faqesh tok me "
+"interpretuesin Javascrip Faster Than Light - duke ju lejuar të shihni "
+"bukurinë e plotë të web-it."
 
 #: activity/activity.info:4
 msgid "To help in researching, Browse offers many features:"
-msgstr ""
+msgstr "Për t’ju ndihmuar në kërkime, Shfletoni ofron mjaft veçori:"
 
 #: activity/activity.info:4
 msgid ""
 "Bookmark (save) good pages you find - never loose good resources or forget "
 "to add them to your bibliography"
 msgstr ""
+"Faqeruani (ruani) faqe të goditura që gjeni - mos humbni kurrë burime të "
+"përshtatshme ose të harroni t’i shtoni ato te bibliografia juaj"
 
 #: activity/activity.info:4
 msgid ""
 "Bookmark pages with collaborators in real time - great for researching as a "
 "group or teachers showing pages to their class"
 msgstr ""
+"Faqeruani aty për aty faqe me bashkëpunëtorë tuajt - e bukur për kërkim si "
+"një grup ose për mësues që t’u tregojnë faqe klasave të tyre"
 
 #: activity/activity.info:4
 msgid ""
 "Comment on your bookmarked pages - a great tool for making curated "
 "collections"
 msgstr ""
+"Komentoni në faqet që keni faqeruajtur - një mjet i goditur për të krijuar "
+"koleksione me përkujdesje"
 
 #: browser.py:275
 #, python-format
 msgid "This tab has crashed Browse: %s"
-msgstr ""
+msgstr "Kjo skedë bëri të vithiset Shfletoni: %s"
 
 #: browser.py:276
 msgid "If you reopen the tab, it may just crash again"
-msgstr ""
+msgstr "Nëse e rihapni këtë skedë, mund të vithiset prapë"
 
 #: browser.py:277
 msgid "Reopen"
-msgstr ""
+msgstr "Rihape"
 
 #: browser.py:278
 msgid "Disregard"
-msgstr ""
+msgstr "Hidhe tej"
 
 #: browser.py:558 browser.py:603 browser.py:604 webactivity.py:351
 msgid "Untitled"
@@ -104,24 +112,24 @@ msgstr "Riprovoni"
 
 #: browser.py:866
 msgid "access to your location"
-msgstr ""
+msgstr "të hyjë te vendndodhja juaj"
 
 #: browser.py:869
 msgid "to display notifications in the frame"
-msgstr ""
+msgstr "të shfaqë njoftime te korniza"
 
 #: browser.py:881
 #, python-format
 msgid "Allow %s to %s?"
-msgstr ""
+msgstr "Të lejohet %s të %s?"
 
 #: browser.py:884
 msgid "You can change your choice later by reloading the page"
-msgstr ""
+msgstr "Zgjedhjen tuaj mund ta ndryshoni më vonë duke ringarkuar këtë faqe"
 
 #: webactivity.py:183
 msgid "Bookmarks"
-msgstr ""
+msgstr "Faqerojtës"
 
 #: webactivity.py:398
 msgid "The initial page was configured"
@@ -155,7 +163,7 @@ msgstr "Ndale"
 
 #: webtoolbar.py:360
 msgid "Show Web Inspector"
-msgstr ""
+msgstr "Shfaq Mbikëqyrës Web"
 
 #: webtoolbar.py:369
 msgid "Home page"
@@ -183,7 +191,7 @@ msgstr "Përpara"
 
 #: webtoolbar.py:456 webtoolbar.py:514
 msgid "No Downloads Running"
-msgstr ""
+msgstr "S’ka Shkarkime Në Përmbushje e Sipër"
 
 #: webtoolbar.py:463
 msgid "Bookmark"
@@ -191,11 +199,11 @@ msgstr "Faqeruajeni"
 
 #: webtoolbar.py:508
 msgid "{}% Downloaded"
-msgstr ""
+msgstr "Shkarkuar {}%"
 
 #: webtoolbar.py:762
 msgid "No Title"
-msgstr ""
+msgstr "S’ka Titull"
 
 #: downloadmanager.py:140
 msgid "Not enough space to download"
@@ -256,7 +264,7 @@ msgstr "Hiqe"
 
 #: linkbutton.py:152
 msgid "Take notes on this page"
-msgstr ""
+msgstr "Mbani shënim në këtë faqe"
 
 #: viewtoolbar.py:39 pdfviewer.py:94
 msgid "Zoom out"
@@ -328,7 +336,7 @@ msgstr "Kopjo lidhjen"
 
 #: palettes.py:191
 msgid "Copy link text"
-msgstr ""
+msgstr "Kopjo tekst lidhjeje"
 
 #: palettes.py:206
 msgid "Copy image"

--- a/webactivity.py
+++ b/webactivity.py
@@ -29,13 +29,13 @@ try:
 except:
     incompatible = True
 gi.require_version('SoupGNOME', '2.4')
-gi.require_version('GConf', '2.0')
 
 from gi.repository import GObject
 GObject.threads_init()
 
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Gio
 from gi.repository import WebKit2
 from gi.repository import Soup
 from gi.repository import SoupGNOME
@@ -44,7 +44,6 @@ from base64 import b64decode, b64encode
 import time
 import shutil
 import json
-from gi.repository import GConf
 import cairo
 import StringIO
 from hashlib import sha1
@@ -103,14 +102,14 @@ def _seed_xs_cookie(cookie_jar):
     if the cookie already exists.
 
     """
-    client = GConf.Client.get_default()
-    backup_url = client.get_string('/desktop/sugar/backup_url')
+    settings = Gio.Settings('org.sugarlabs')
+    backup_url = settings.get_string('backup-url')
     if not backup_url:
         _logger.debug('seed_xs_cookie: Not registered with Schoolserver')
         return
 
-    jabber_server = client.get_string(
-        '/desktop/sugar/collaboration/jabber_server')
+    settings = Gio.Settings('org.sugarlabs.collaboration')
+    jabber_server = settings.get_string('jabber-server')
 
     soup_uri = Soup.URI()
     soup_uri.set_scheme('xmpp')
@@ -418,7 +417,7 @@ class WebActivity(activity.Activity):
         self._tabbed_view.load_homepage()
 
     def _go_library_button_cb(self, button):
-        self._tabbed_view.load_homepage(ignore_gconf=True)
+        self._tabbed_view.load_homepage(ignore_settings=True)
 
     def _set_home_button_cb(self, button):
         self._tabbed_view.set_homepage()

--- a/webtoolbar.py
+++ b/webtoolbar.py
@@ -23,7 +23,7 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import Gdk
-from gi.repository import GConf
+from gi.repository import Gio
 from gi.repository import Pango
 
 from sugar3.graphics.toolbutton import ToolButton
@@ -40,7 +40,7 @@ import filepicker
 import places
 import downloadmanager
 from browser import Browser
-from browser import HOME_PAGE_GCONF_KEY, LIBRARY_PATH
+from browser import SETTINGS_KEY_HOME_PAGE, LIBRARY_PATH
 from progresstoolbutton import ProgressToolButton
 
 from pdfviewer import DummyBrowser
@@ -383,9 +383,8 @@ class PrimaryToolbar(ToolbarBase):
         menu_box.show_all()
 
         # verify if the home page is configured
-        client = GConf.Client.get_default()
-        self._reset_home_menu.set_visible(
-            client.get_string(HOME_PAGE_GCONF_KEY) is not None)
+        home_page = tabbed_view.settings.get_string(SETTINGS_KEY_HOME_PAGE)
+        self._reset_home_menu.set_visible(home_page != '')
 
         toolbar.insert(self._go_home, -1)
         self._go_home.show()


### PR DESCRIPTION
Port from GConf to Gio.Settings using staged release.

Browse uses three settings;
* `backup-url`, part of Sugar, maintained by Sugar 0.112 in _GConf_ and _Gio.Settings,_
* `jabber-server`, part of Sugar, maintained by Sugar 0.112 in _GConf_ and _Gio.Settings_,
* `home-page`, private to Browse only.

Staged release plan;
* v201.5 is to store `home-page` in an activity specific _Gio.SettingsSchemaSource_, and compile the schema on first start,
* v202 is to drop _GConf_ support.

Branch also contains release tags.

Tested on Ubuntu 16.04.
