### PR TITLE
Change search engine to DuckDuckGo

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -212,14 +212,8 @@ class TabbedView(BrowserNotebook):
                 pass
 
         if soup_uri is None and not _NON_SEARCH_REGEX.match(url):
-            # Get the user's LANG to use as default language of
-            # the results
-            locale = os.environ.get('LANG', '')
-            language_location = locale.split('.', 1)[0].lower()
-            language = language_location.split('_')[0]
             # If the string doesn't look like an URI, let's search it:
-            url_search = 'http://www.google.com/search?' \
-                'q=%(query)s&ie=UTF-8&oe=UTF-8&hl=%(language)s'
+            url_search = 'http://duckduckgo.com/?q=%(query)s'
             query_param = Soup.form_encode_hash({'q': url})
             # [2:] here is getting rid of 'q=':
             effective_url = url_search % {'query': query_param[2:],

--- a/data/index.html
+++ b/data/index.html
@@ -66,9 +66,9 @@ document.write("\" alt=\"Sugar Labs\" width=\"750\" height=\"250\" border=\"0\"/
 </script>
 <table border="0" cellspacing="0" cellpadding="0" width="700px"><tr>
 <td width="130px" align="center">
-<form action="http://google.com/search" name="f" target="_top">
+<form action="http://duckduckgo.com/" name="f" target="_top">
 <input name="hl" type="hidden" value="en"/>
-<br/><br/><input maxlength="2048" name="q" size="35" title="Google Search" value=""/> <input name="btnG" type="submit" value="Google Search"/>
+<br/><br/><input maxlength="2048" name="q" size="35" title="Search with DuckDuckGo" value=""/> <input name="button" type="submit" value="Search with DuckDuckGo"/>
 </form>
 </td>
 </tr></table>


### PR DESCRIPTION
This pull request will change the Browse activity's default search engine to DuckDuckGo, as happened previously in the GNOME Web browser. DuckDuckGo's data privacy principles are in line with those of the free software movement.

The language matching code will be removed, as, according to <https://duckduckgo.com/params>, DuckDuckGo's search language codes are not POSIX-compliant.