### PR TITLE
Allow users to configure the preferred search engine

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,48 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+import os
+import sys
+
 from sugar3.activity import bundlebuilder
 
 bundlebuilder.start()
+
+try:
+    if sys.argv.index('install'):
+        # create schemas directory if missing
+        path = '/usr/share/glib-2.0/schemas'
+        if not os.access(path, os.F_OK):
+            os.makedirs(path)
+
+        # create compiled schema file if missing
+        src = 'org.laptop.WebActivity.gschema.xml'
+        lines = \
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<schemalist>',
+                '<schema id="org.laptop.WebActivity" '
+                'path="/org/laptop/WebActivity/">',
+                '<key name="home-page" type="s">',
+                "<default>''</default>",
+                '<summary>Home page URL</summary>',
+                '<description>URL to show as default or when home button '
+                'is pressed.</description>',
+                '</key>',
+                '<key name="search-engine-url" type="s">',
+                "<default>'http://www.google.com/search?q=%(query)s"
+                "&amp;ie=UTF-8&amp;oe=UTF-8&amp;hl=%(language)s'</default>",
+                '<summary>Search engine URL</summary>',
+                '<description>URL to which to submit search '
+                'results. Parameters: %(query)s: The search query. '
+                '%(language)s: A POSIX-compliant language string '
+                'describing the language of the result '
+                'page.</description>',
+                '</key>',
+                '</schema>',
+                '</schemalist>',
+            ]
+        open(os.path.join(path, src), 'w').writelines(lines)
+        os.system('glib-compile-schemas %s' % path)
+except ValueError:
+    pass


### PR DESCRIPTION
This patch will make it easier for users to configure the search engine they prefer to use with Browse. Please note that, if this patch is applied, installation of Browse will require root access (and may not be chroot safe), as GLib cannot read GSettings schema files installed in the activity's bundle directory.