### PR TITLE
Delete the activity bundle after downloading and installation

### DIFF
--- a/downloadmanager.py
+++ b/downloadmanager.py
@@ -271,6 +271,12 @@ class Download(object):
         self._stop_alert.connect('response', self.__stop_response_cb)
         self._stop_alert.show()
 
+    def remove_journal_object(self):
+        datastore.delete(self._object_id)
+        self._object_id = None
+        if os.path.isfile(self._dest_path):
+            os.remove(self._dest_path)
+
     def __download_failed_cb(self, download, error):
         logging.error('Error downloading URI due to %s'
                       % error)
@@ -305,6 +311,7 @@ class Download(object):
             launch_bundle(object_id=self._object_id)
         if response_id == Gtk.ResponseType.ACCEPT:
             activity.show_object_in_journal(self._object_id)
+        self.remove_journal_object()
         self._activity.remove_alert(alert)
 
     def cleanup(self):


### PR DESCRIPTION
Fixes #81 
**Changes**
1) `downloadmanager.py`

**Updates**
On downloading a new activity, from `activities.sugarlabs.org`, the activity bundle is installed and the activity bundle is deleted from the journal.

Reason why the activity bundle was being shown in the journal is that, it was never removed from journal before.
One side effect is that on deleting the activity bundle from the journal, the `Show in Journal` option returns immediately to the journal, and does not display the details of the activity.

Is there a way to remove the activity bundle from the journal, without losing the `Show in Journal` option.

Thanks