### PR TITLE
Enhance browser homepage with customisation

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -1,73 +1,77 @@
 <!DOCTYPE html>
 <html>
-<head>
-<script type="text/javascript" language="JavaScript">
-logos = new Array();
-logos = ['logo_white_01.png', 'logo_white_02.png', 'logo_white_03.png', 'logo_white_04.png', 'logo_white_05.png', 'logo_white_06.png', 'logo_white_07.png', 'logo_white_08.png', 'logo_white_09.png', 'logo_white_10.png', 'logo_white_11.png', 'logo_white_12.png'];
-link_colours = new Array();
-link_colours = ['link1', 'link2', 'link3', 'link4', 'link5', 'link6', 'link7', 'link8', 'link9', 'link10', 'link11', 'link12'];
-r = Math.round(Math.random() * 11);
-function logo_filename() {
-    return logos[r]
-}
-function link_colour() {
-    return link_colours[r]
-}
-</script>
-<style type="text/css">
-html { 	margin-right: 8px; 	margin-left: 8px; 	font-family: Helvetica, Arial, sans-serif;}
-.links-container { 	padding-bottom: 4px; 	padding-top: 4px; 	display: block; 	text-align: right;}
-.link1 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #006e00;}
-.link1:hover { color: white; background-color: #006e00;}
-.link2 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
-.link2:hover { color: white; background-color: #033cd2;}
-.link3 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #006e00;}
-.link3:hover { color: white; background-color: #006e00;}
-.link4 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
-.link4:hover { color: white; background-color: #033cd2;}
-.link5 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #6e008c;}
-.link5:hover { color: white; background-color: #6e008c;}
-.link6 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #a00000;}
-.link6:hover { color: white; background-color: #a00000;}
-.link7 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
-.link7:hover { color: white; background-color: #033cd2;}
-.link8 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #6e008c;}
-.link8:hover { color: white; background-color: #6e008c;}
-.link9 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #6e008c;}
-.link9:hover { color: white; background-color: #6e008c;}
-.link10 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
-.link10:hover { color: white; background-color: #033cd2;}
-.link11 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #006e00;}
-.link11:hover { color: white; background-color: #006e00; }
-.link12 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
-.link12:hover { color: white; background-color: #033cd2;}
-.search{background: #FFFFFF; border-radius: 25px; border-width: 0.5px; border-color: #686868; height: 43px;width: 400px; outline: 0; padding: 0; padding-left: 5px; padding-right: 5px; margin: 0}
-.btn{background: #5A89EB; border-radius: 25px; width: 121px;height: 45px;color:#FFFFFF;font-size: 13px;font-style: normal; border-color: #FFFFFF; padding:0; margin: 0; margin-left: 5px; outline: 0}
-</style>
-<title>Sugar Labs</title>
-<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
-<link rel="shortcut icon" href="favicon_01.png"/>
-</head>
-<body>
-<div class="links-container">
-<script type="text/javascript" language="JavaScript">
-document.write("<a class='" + link_colour() + "' href='https://www.sugarlabs.org/'>sugar labs</a> / <a class='" + link_colour() + "' href='https://wiki.sugarlabs.org/'>wiki</a> / <a class='" + link_colour() + "' href='https://bugs.sugarlabs.org/'>bugs</a> / <a class='" + link_colour() + "' href='http://schoolserver/'>school</a> / <a class='" + link_colour() + "' href='http://activities.sugarlabs.org/'>activities</a>")
-</script>
-</div>>
-<center>
-<script type="text/javascript" language="JavaScript">
-document.write("<br/><br/><br/><a href='https://www.sugarlabs.org/'><img src='")
-document.write(logo_filename())
-document.write("' alt='Sugar Labs' width='750' height='250' position='static' border='0'/></a><br/><br/>")
-</script>
-<table border="0" cellspacing="0" cellpadding="0" width="700px"><tr>
-<td width="130px" align="center">
-<form action="http://google.com/search" name="f" target="_top">
-<input name="hl" type="hidden" value="en"/>
-<br/><br/><input class="search" type="text" maxlength="2048" name="q" size="35" title="Google Search" value="" autofocus/><input class= "btn" name="btnG" type="submit" value="Google Search"/>
-</form>
-</td>
-</tr></table>
-</center>
-</body>
+    <head>
+        <script type="text/javascript" language="JavaScript">
+            logos = new Array();
+            logos = ['logo_white_01.png', 'logo_white_02.png', 'logo_white_03.png', 'logo_white_04.png', 'logo_white_05.png', 'logo_white_06.png', 'logo_white_07.png', 'logo_white_08.png', 'logo_white_09.png', 'logo_white_10.png', 'logo_white_11.png', 'logo_white_12.png'];
+            link_colours = new Array();
+            link_colours = ['link1', 'link2', 'link3', 'link4', 'link5', 'link6', 'link7', 'link8', 'link9', 'link10', 'link11', 'link12'];
+            r = Math.round(Math.random() * 11);
+            function logo_filename() {
+                return logos[r]
+            }
+            function link_colour() {
+                return link_colours[r]
+            }
+        </script>
+        <style type="text/css">
+            html {  margin-right: 8px; 	margin-left: 8px; 	font-family: Helvetica, Arial, sans-serif;}
+            .links-container { 	padding-bottom: 4px; 	padding-top: 4px; 	display: block; 	text-align: right;}
+            .link1 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #006e00;}
+            .link1:hover { color: white; background-color: #006e00;}
+            .link2 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
+            .link2:hover { color: white; background-color: #033cd2;}
+            .link3 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #006e00;}
+            .link3:hover { color: white; background-color: #006e00;}
+            .link4 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
+            .link4:hover { color: white; background-color: #033cd2;}
+            .link5 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #6e008c;}
+            .link5:hover { color: white; background-color: #6e008c;}
+            .link6 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #a00000;}
+            .link6:hover { color: white; background-color: #a00000;}
+            .link7 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
+            .link7:hover { color: white; background-color: #033cd2;}
+            .link8 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #6e008c;}
+            .link8:hover { color: white; background-color: #6e008c;}
+            .link9 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #6e008c;}
+            .link9:hover { color: white; background-color: #6e008c;}
+            .link10 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
+            .link10:hover { color: white; background-color: #033cd2;}
+            .link11 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #006e00;}
+            .link11:hover { color: white; background-color: #006e00; }
+            .link12 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
+            .link12:hover { color: white; background-color: #033cd2;}
+
+            .search{background: #FFFFFF; border-radius: 25px; border-width: 0.5px; border-color: #686868; height: 43px;width: 400px; outline: 0; padding: 0; padding-left: 5px; padding-right: 5px; margin: 0}
+            .btn{background: #5A89EB; border-radius: 25px; width: 121px;height: 45px;color:#FFFFFF;font-size: 13px;font-style: normal; border-color: #FFFFFF; padding:0; margin: 0; margin-left: 5px; outline: 0}
+        </style>
+        <title>Sugar Labs</title>
+        <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+        <link rel="shortcut icon" href="favicon_01.png"/>
+    </head>
+    <body>
+        <div class="links-container">
+            <script type="text/javascript" language="JavaScript">
+                document.write("<a class='" + link_colour() + "' href='https://www.sugarlabs.org/'>sugar labs</a> / <a class='" + link_colour() + "' href='https://wiki.sugarlabs.org/'>wiki</a> / <a class='" + link_colour() + "' href='https://bugs.sugarlabs.org/'>bugs</a> / <a class='" + link_colour() + "' href='http://schoolserver/'>school</a> / <a class='" + link_colour() + "' href='http://activities.sugarlabs.org/'>activities</a>")
+            </script>
+        </div>>
+        <center>
+            <script type="text/javascript" language="JavaScript">
+                document.write("<br/><br/><br/><a href='https://www.sugarlabs.org/'><img src='")
+                document.write(logo_filename())
+                document.write("' alt='Sugar Labs' width='750' height='250' position='static' border='0'/></a><br/><br/>")
+            </script>
+            <table border="0" cellspacing="0" cellpadding="0" width="700px">
+                <tr>
+                    <td width="130px" align="center">
+                        <form action="http://google.com/search" name="f" target="_top">
+                            <input name="hl" type="hidden" value="en"/>
+                            <br><br>
+                            <input class="search" type="text" maxlength="2048" name="q" size="35" title="Google Search" value="" autofocus/><input class= "btn" name="btnG" type="submit" value="Google Search"/>
+                        </form>
+                    </td>
+                </tr>
+            </table>
+        </center>
+    </body>
 </html>

--- a/data/index.html
+++ b/data/index.html
@@ -41,9 +41,9 @@
             .link11:hover { color: white; background-color: #006e00; }
             .link12 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
             .link12:hover { color: white; background-color: #033cd2;}
-
-            .search{background: #FFFFFF; border-radius: 25px; border-width: 0.5px; border-color: #686868; height: 43px;width: 400px; outline: 0; padding: 0; padding-left: 5px; padding-right: 5px; margin: 0}
-            .btn{background: #5A89EB; border-radius: 25px; width: 121px;height: 45px;color:#FFFFFF;font-size: 13px;font-style: normal; border-color: #FFFFFF; padding:0; margin: 0; margin-left: 5px; outline: 0}
+            .center {text-align: center; position: static; border: 0}
+            .search{background: #FFFFFF; border-radius: 25px; border-width: 1px; border-color: #686868; height: 32px; width: 45%; outline: 0; padding: 0; padding-left: 5px; padding-right: 5px; margin: 0}
+            .btn{background: #5A89EB; border-radius: 25px; width: 15%; height: 32px; color:#FFFFFF; font-style: normal; border-color: #FFFFFF; padding:0; margin: 0; margin-left: 5px; outline: 0}
         </style>
         <title>Sugar Labs</title>
         <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
@@ -54,24 +54,25 @@
             <script type="text/javascript" language="JavaScript">
                 document.write("<a class='" + link_colour() + "' href='https://www.sugarlabs.org/'>sugar labs</a> / <a class='" + link_colour() + "' href='https://wiki.sugarlabs.org/'>wiki</a> / <a class='" + link_colour() + "' href='https://bugs.sugarlabs.org/'>bugs</a> / <a class='" + link_colour() + "' href='http://schoolserver/'>school</a> / <a class='" + link_colour() + "' href='http://activities.sugarlabs.org/'>activities</a>")
             </script>
-        </div>>
-        <center>
-            <script type="text/javascript" language="JavaScript">
-                document.write("<br/><br/><br/><a href='https://www.sugarlabs.org/'><img src='")
-                document.write(logo_filename())
-                document.write("' alt='Sugar Labs' width='750' height='250' position='static' border='0'/></a><br/><br/>")
-            </script>
-            <table border="0" cellspacing="0" cellpadding="0" width="700px">
-                <tr>
-                    <td width="130px" align="center">
-                        <form action="http://google.com/search" name="f" target="_top">
-                            <input name="hl" type="hidden" value="en"/>
-                            <br><br>
-                            <input class="search" type="text" maxlength="2048" name="q" size="35" title="Google Search" value="" autofocus/><input class= "btn" name="btnG" type="submit" value="Google Search"/>
+        </div>
+        <div class="center">
+            <div style="display: inline-block">
+                <script type="text/javascript" language="JavaScript">
+                    document.write("<br><br><br><a href='https://www.sugarlabs.org/'><img src='")
+                    document.write(logo_filename())
+                    document.write("' alt='Sugar Labs' width='100%' height='250'></a><br><br>")
+                </script>
+                <table style="border: 0; width: 100%" cellspacing="0" cellpadding="0">
+                    <tr><td>
+                        <form style="width: 100%" action="http://google.com/search" name="f" target="_top">
+                            <div>
+                                <input class="search" type="search" maxlength="2048" name="q" title="Google Search" value="" autofocus>
+                                <input class= "btn" name="btnG" type="submit" value="Google Search">
+                            </div>
                         </form>
-                    </td>
-                </tr>
-            </table>
-        </center>
+                    </td></tr>
+                </table>
+            </div>
+        </div>
     </body>
 </html>

--- a/data/index.html
+++ b/data/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <script type="text/javascript" language="JavaScript">
-<!--
 logos = new Array();
 logos = ['logo_white_01.png', 'logo_white_02.png', 'logo_white_03.png', 'logo_white_04.png', 'logo_white_05.png', 'logo_white_06.png', 'logo_white_07.png', 'logo_white_08.png', 'logo_white_09.png', 'logo_white_10.png', 'logo_white_11.png', 'logo_white_12.png'];
 link_colours = new Array();
@@ -14,7 +13,6 @@ function logo_filename() {
 function link_colour() {
     return link_colours[r]
 }
--->
 </script>
 <style type="text/css">
 html { 	margin-right: 8px; 	margin-left: 8px; 	font-family: Helvetica, Arial, sans-serif;}
@@ -43,6 +41,8 @@ html { 	margin-right: 8px; 	margin-left: 8px; 	font-family: Helvetica, Arial, sa
 .link11:hover { color: white; background-color: #006e00; }
 .link12 { padding-bottom: 4px; padding-top: 4px; text-decoration: none; color: #033cd2;}
 .link12:hover { color: white; background-color: #033cd2;}
+.search{background: #FFFFFF; border-radius: 25px; border-width: 0.5px; border-color: #686868; height: 43px;width: 400px; outline: 0; padding: 0; padding-left: 5px; padding-right: 5px; margin: 0}
+.btn{background: #5A89EB; border-radius: 25px; width: 121px;height: 45px;color:#FFFFFF;font-size: 13px;font-style: normal; border-color: #FFFFFF; padding:0; margin: 0; margin-left: 5px; outline: 0}
 </style>
 <title>Sugar Labs</title>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
@@ -51,24 +51,20 @@ html { 	margin-right: 8px; 	margin-left: 8px; 	font-family: Helvetica, Arial, sa
 <body>
 <div class="links-container">
 <script type="text/javascript" language="JavaScript">
-<!--
-document.write("<a class=\"" + link_colour() + "\" href=\"https://www.sugarlabs.org/\">sugar labs</a> / <a class=\"" + link_colour() + "\" href=\"https://wiki.sugarlabs.org/\">wiki</a> / <a class=\"" + link_colour() + "\" href=\"https://bugs.sugarlabs.org/\">bugs</a> / <a class=\"" + link_colour() + "\" href=\"http://schoolserver/\">school</a> / <a class=\"" + link_colour() + "\" href=\"http://activities.sugarlabs.org/\">activities</a>")
--->
+document.write("<a class='" + link_colour() + "' href='https://www.sugarlabs.org/'>sugar labs</a> / <a class='" + link_colour() + "' href='https://wiki.sugarlabs.org/'>wiki</a> / <a class='" + link_colour() + "' href='https://bugs.sugarlabs.org/'>bugs</a> / <a class='" + link_colour() + "' href='http://schoolserver/'>school</a> / <a class='" + link_colour() + "' href='http://activities.sugarlabs.org/'>activities</a>")
 </script>
-</div>
+</div>>
 <center>
 <script type="text/javascript" language="JavaScript">
-<!--
-document.write("<br/><br/><br/><a href=\"https://www.sugarlabs.org/\"><img src=\"")
+document.write("<br/><br/><br/><a href='https://www.sugarlabs.org/'><img src='")
 document.write(logo_filename())
-document.write("\" alt=\"Sugar Labs\" width=\"750\" height=\"250\" border=\"0\"/></a><br/><br/>")
--->
+document.write("' alt='Sugar Labs' width='750' height='250' position='static' border='0'/></a><br/><br/>")
 </script>
 <table border="0" cellspacing="0" cellpadding="0" width="700px"><tr>
 <td width="130px" align="center">
 <form action="http://google.com/search" name="f" target="_top">
 <input name="hl" type="hidden" value="en"/>
-<br/><br/><input maxlength="2048" name="q" size="35" title="Google Search" value=""/> <input name="btnG" type="submit" value="Google Search"/>
+<br/><br/><input class="search" type="text" maxlength="2048" name="q" size="35" title="Google Search" value="" autofocus/><input class= "btn" name="btnG" type="submit" value="Google Search"/>
 </form>
 </td>
 </tr></table>


### PR DESCRIPTION
Fixes #87 

**Changes**
1) `index.html`

**Updates**
1) Autofocus to the Google Search bar, so that a user can start typing in without having to click first
2) Increased the size of the google search bar and button, to make it easier to find and click
3) Changed the shape of the Google search bar and button to rectangles with rounded edges, to make it similar to an actual google search bar, as shown on most browsers
4) Added equal padding to the text that's entered within the search box.

I have added @samswag  as a co-author in the commit message, as I borrowed his earlier work on the issue which can be found [here](https://github.com/sugarlabs/browse-activity/pull/88)

Tested on Ubuntu 18.04 and Sugar v0.114