### PR TITLE
Ensure that a PDF is only downloaded once

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -525,12 +525,15 @@ class TabbedView(BrowserNotebook):
         state = []
         for index in range(0, self.get_n_pages()):
             tab_page = self.get_nth_page(index)
-            type_name = TAB_BROWSER
             if isinstance(tab_page, PDFTabPage):
                 type_name = TAB_PDF
+                tab_state = tab_page.browser.get_state()
+            else:
+                type_name = TAB_BROWSER
+                tab_state = tab_page.browser.get_state().decode()
             state.append({
                 'type': type_name,
-                'state': tab_page.browser.get_state().decode()})
+                'state': tab_state})
         return state
 
     def set_session_state(self, states):
@@ -848,19 +851,17 @@ class Browser(WebKit2.WebView):
 
     def __decide_policy_cb(self, webview, policy_decision, decision_type):
         """Handle downloads and PDF files."""
-
         if decision_type != WebKit2.PolicyDecisionType.RESPONSE:
             return False
-
-        response = WebKit2.ResponsePolicyDecision.get_response(policy_decision)
-        mimetype = WebKit2.URIResponse.get_mime_type(response)
+        response = policy_decision.get_response()
+        mimetype = response.get_mime_type()
 
         if mimetype == 'application/pdf':
             # FIXME: this causes two GET requests to the server; at
             # this point the first is in progress and then abandoned,
             # or already completed, then a second GET request is made.
             self.emit('open-pdf', response.get_uri())
-            policy_decision.ignore()
+            policy_decision.download()
             self._activity.unbusy()
             return True
 

--- a/browser.py
+++ b/browser.py
@@ -851,15 +851,14 @@ class Browser(WebKit2.WebView):
 
     def __decide_policy_cb(self, webview, policy_decision, decision_type):
         """Handle downloads and PDF files."""
+
         if decision_type != WebKit2.PolicyDecisionType.RESPONSE:
             return False
-        response = policy_decision.get_response()
-        mimetype = response.get_mime_type()
+
+        response = WebKit2.ResponsePolicyDecision.get_response(policy_decision)
+        mimetype = WebKit2.URIResponse.get_mime_type(response)
 
         if mimetype == 'application/pdf':
-            # FIXME: this causes two GET requests to the server; at
-            # this point the first is in progress and then abandoned,
-            # or already completed, then a second GET request is made.
             self.emit('open-pdf', response.get_uri())
             policy_decision.download()
             self._activity.unbusy()

--- a/pdfviewer.py
+++ b/pdfviewer.py
@@ -503,7 +503,6 @@ class PDFTabPage(Gtk.HBox):
         context = WebKit2.WebContext.get_default()
         context.connect('download-started', self.__download_started_cb)
         downloadmanager.ignore_pdf(remote_uri)
-        context.download_uri(remote_uri)
 
     def __download_started_cb(self, context, download):
         self._download = download


### PR DESCRIPTION
Fixes #54 

**Changes**
1) `browser.py`
2) `pdfviewer.py`

**Updates**
At the present master HEAD (https://github.com/sugarlabs/browse-activity/commit/540c93fa5fe4ca1a741c6460abed2607aa8a8078), if the `mime_type`, in `__decide_policy_cb` is `application/pdf`, a new `GET` request was being issued after setting up the PDF tab in `pdfviewer.py/_download_from_http`, where the `context.download_uri(remote_uri)` was the culprit.

Rather than make a new `GET` request, I used the response obtained from the first `GET` request to download the PDF directly, using the `WebKit2.PolicyDecision.download()`. The function also emits the `download-started` signal which is connected to `pdfviewer.py/__download_started_cb`, which handles the rest.

I found a thread in the WebKit2 mailing list [(here)](https://lists.webkit.org/pipermail/webkit-gtk/2015-January/002239.html), that seems to explain the issue in more detail.

@quozl @pro-panda Please let me know if I have approached this issue in the right step.

Thanks.

Tested on Ubuntu 18.04, Sugar v0.114