### PR TITLE
Fix write error for cert.db (Activities depending on Browse-Activity)

### DIFF
--- a/webactivity.py
+++ b/webactivity.py
@@ -86,7 +86,7 @@ if _profile_version < PROFILE_VERSION:
     else:
         # wikipedia activity use a empty file
         with open(os.path.join(_profile_path, 'cert8.db'), 'w') as cert_file:
-            cert_file.write()
+            cert_file.write('')
 
     os.chmod(os.path.join(_profile_path, 'cert8.db'), 0o660)
 


### PR DESCRIPTION
Activities other than browse activity like Wikipedia wants us to create an empty cert.db. However, `.write` method of Python3, requires some args. To create an empty cert.db, cert_file.write() has to be replaced to cert_file.write('')