### PR TITLE
Fixes

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -44,7 +44,7 @@ import globalhistory
 from pdfviewer import PDFTabPage
 
 # Sugar is relative to 100x (XO), the web is relative to 72x (desktop) scale
-ZOOM_ORIGINAL = style.zoom(100 * 100 / 72) / 100.0
+ZOOM_ORIGINAL = style.zoom(100 * 100 // 72) / 100.0
 _ZOOM_AMOUNT = 0.1
 LIBRARY_PATH = '/usr/share/library-common/index.html'
 

--- a/collabwrapper.py
+++ b/collabwrapper.py
@@ -401,20 +401,25 @@ class CollabWrapper(GObject.GObject):
         return self._leader
 
 
-FT_STATE_NONE = 0
-FT_STATE_PENDING = 1
-FT_STATE_ACCEPTED = 2
-FT_STATE_OPEN = 3
-FT_STATE_COMPLETED = 4
-FT_STATE_CANCELLED = 5
+FT_STATE_NONE = TelepathyGLib.FileTransferState.NONE
+FT_STATE_PENDING = TelepathyGLib.FileTransferState.PENDING
+FT_STATE_ACCEPTED = TelepathyGLib.FileTransferState.ACCEPTED
+FT_STATE_OPEN = TelepathyGLib.FileTransferState.OPEN
+FT_STATE_COMPLETED = TelepathyGLib.FileTransferState.COMPLETED
+FT_STATE_CANCELLED = TelepathyGLib.FileTransferState.CANCELLED
 
-FT_REASON_NONE = 0
-FT_REASON_REQUESTED = 1
-FT_REASON_LOCAL_STOPPED = 2
-FT_REASON_REMOTE_STOPPED = 3
-FT_REASON_LOCAL_ERROR = 4
-FT_REASON_LOCAL_ERROR = 5
-FT_REASON_REMOTE_ERROR = 6
+FT_REASON_NONE = \
+    TelepathyGLib.FileTransferStateChangeReason.NONE
+FT_REASON_REQUESTED = \
+    TelepathyGLib.FileTransferStateChangeReason.REQUESTED
+FT_REASON_LOCAL_STOPPED = \
+    TelepathyGLib.FileTransferStateChangeReason.LOCAL_STOPPED
+FT_REASON_REMOTE_STOPPED = \
+    TelepathyGLib.FileTransferStateChangeReason.REMOTE_STOPPED
+FT_REASON_LOCAL_ERROR = \
+    TelepathyGLib.FileTransferStateChangeReason.LOCAL_ERROR
+FT_REASON_REMOTE_ERROR = \
+    TelepathyGLib.FileTransferStateChangeReason.REMOTE_ERROR
 
 
 class _BaseFileTransfer(GObject.GObject):

--- a/collabwrapper.py
+++ b/collabwrapper.py
@@ -729,7 +729,7 @@ class OutgoingBlobTransfer(_BaseOutgoingTransfer):
         _BaseOutgoingTransfer.__init__(
             self, buddy, conn, filename, description, mime)
 
-        self._blob = blob
+        self._blob = blob.encode('utf-8')
         self._create_channel(len(self._blob))
 
     def _get_input_stream(self):

--- a/pdfviewer.py
+++ b/pdfviewer.py
@@ -549,7 +549,7 @@ class PDFTabPage(Gtk.HBox):
 
     def __download_finished_cb(self, download):
         self._pdf_uri = download.get_destination()
-        logging.error('FINISHED %s', self._pdf_uri)
+        logging.debug('FINISHED %s', self._pdf_uri)
         self.remove(self._message_box)
         self._message_box = None
         self._show_pdf()

--- a/pdfviewer.py
+++ b/pdfviewer.py
@@ -328,6 +328,19 @@ class DummyBrowser(GObject.GObject):
     def get_window(self):
         return self._tab.get_window()
 
+    def get_allocation(self):
+        return self._tab.get_allocation()
+
+    def translate_coordinates(self, widget, x, y):
+        return self._tab.translate_coordinates(widget, x, y)
+
+    # FIXME provide implementations
+    def can_execute_editing_command_finish(self):
+        pass
+
+    def get_find_controller(self):
+        return
+
 
 class PDFProgressMessageBox(Gtk.EventBox):
     def __init__(self, message, button_callback):
@@ -456,7 +469,6 @@ class PDFTabPage(Gtk.HBox):
             self._browser.props.title = title
 
         self._browser.props.uri = requested_uri
-
         # show PDF directly if the file is local (from the system tree
         # or from the journal)
 

--- a/webactivity.py
+++ b/webactivity.py
@@ -411,7 +411,7 @@ class WebActivity(activity.Activity):
     def __link_remove_button_cb(self, button):
         browser = self._tabbed_view.props.current_browser
         uri = browser.get_uri()
-        self.__link_removed_cb(None, sha1(uri).hexdigest())
+        self.__link_removed_cb(None, sha1(uri.encode('utf-8')).hexdigest())
 
     def _go_home_button_cb(self, button):
         self._tabbed_view.load_homepage()

--- a/webtoolbar.py
+++ b/webtoolbar.py
@@ -170,7 +170,8 @@ class WebEntry(iconentry.IconEntry):
 
         search_text = self.props.text
         for place in places.get_store().search(search_text):
-            title = '<span weight="bold" >%s</span>' % (place.title)
+            title = '<span weight="bold" >%s</span>' % (GLib.markup_escape_text(place.title))
+            place.uri = GLib.markup_escape_text(place.uri)
             list_store.append([title + '\n' + place.uri, place.uri])
 
         self._search_view.set_model(list_store)


### PR DESCRIPTION
- [x] TypeError: Item 0: Must be number, not str
- [x] (sugar-activity3:7184): Gtk-WARNING **: 16:25:08.511: Failed to set text from markup due to error parsing markup: Error on line 2: Entity did not end with a semicolon; most likely you used an ampersand character withouxt intending to start an entity — escape ampersand as &
@quozl @srevinsaju @JuiP Please review.
This pull requests addresses errors reported by @shaansubbaiah in [mailing list](http://lists.sugarlabs.org/archive/sugar-devel/2020-June/058458.html).