### PR TITLE
Fixes

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -81,13 +81,10 @@ def _get_sugar_version():
     global _sugar_version
     if _sugar_version is None:
         if 'SUGAR_VERSION' in os.environ:
-            version = os.environ['SUGAR_VERSION']
-            major, minor = version.split('.')[0:2]
-            # use the last stable version
-            _sugar_version = '%s.%s' % (major, int(minor) - int(minor) % 2)
+            _sugar_version = os.environ['SUGAR_VERSION']
         else:
             logging.error('SUGAR_VERSION env variable not found')
-            _sugar_version = '0.100'
+            _sugar_version = '0.114'
     return _sugar_version
 
 

--- a/palettes.py
+++ b/palettes.py
@@ -245,7 +245,12 @@ class BrowsePalette(Palette):
     def __copy_image_activate_cb(self, menu_item):
         # Download the image
         temp_file = tempfile.NamedTemporaryFile(delete=False)
-        data = urllib.request.urlopen(self._image_url).read()
+
+        user_agent = self._browser.get_settings().props.user_agent
+        req = urllib.request.Request(self._image_url)
+        req.add_header('User-Agent', user_agent)
+        data = urllib.request.urlopen(req).read()
+
         temp_file.write(data)
         temp_file.close()
 


### PR DESCRIPTION
Fixes the `HTTP 403 Error` due to websites blocking requests with the `urllib` user-agent. Uses the Browse/WebKit2 user-agent.

Also sets the Sugar version in the user-agent to the latest release, and uses `114` as the fallback, in case the `SUGAR_VERSION` env variable is missing.