### PR TITLE
Use standard icon name

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -35,7 +35,7 @@ class TabAdd(Gtk.HBox):
     def __init__(self):
         GObject.GObject.__init__(self)
 
-        add_tab_icon = Icon(icon_name='add')
+        add_tab_icon = Icon(icon_name='list-add')
         button = Gtk.Button()
         button.drag_dest_set(0, [], 0)
         button.props.relief = Gtk.ReliefStyle.NONE


### PR DESCRIPTION
`list-add` is the standard name.

References:
* https://specifications.freedesktop.org/icon-naming-spec/latest/#actions
* https://github.com/sugarlabs/sugar-artwork/blob/master/icons/scalable/actions/list-add.svg