### PR TITLE
fix(browse): run downloaded activity instead of opening bundle in Dev…

### DIFF
--- a/downloadmanager.py
+++ b/downloadmanager.py
@@ -248,10 +248,14 @@ class Download(object):
         self._stop_alert.props.msg = self._suggested_filename
 
         bundle = None
-        if _HAS_BUNDLE_LAUNCHER:
+        if _HAS_BUNDLE_LAUNCHER and mime_type != 'application/vnd.olpc-sugar':
             bundle = get_bundle(object_id=self._object_id)
 
-        if bundle is not None:
+        if mime_type == 'application/vnd.olpc-sugar':
+            icon = Icon(icon_name='media-playback-start')
+            label = _('Run downloaded activity')
+            response_id = Gtk.ResponseType.APPLY
+        elif bundle is not None:
             icon = Icon(file=bundle.get_icon())
             label = _('Open with %s') % bundle.get_name()
             response_id = Gtk.ResponseType.APPLY


### PR DESCRIPTION
fixes #56
Description:
 When the Develop activity is present, and a bundle is downloaded via Browse, the download completion alert was incorrectly offers to "Open with Develop" instead of running the downloaded activity directly.

Changes:
Modified [downloadmanager.py]
 When a bundle is detected, the alert now displays the "Run downloaded activity" button instead of looking up the Develop activity handler
 Non-activity downloads continue to show the existing behaviour: "Open with..." or "Show in Journal"

Behavior:
Before: Bundles → "Open with Develop" (incorrect)
After: Bundles → "Run downloaded activity" (direct launch)

Testing:
Download a .xo activity bundle and verify the completion alert shows the correct "Run downloaded activity" button
Download non-activity files to confirm existing behaviour is preserved

